### PR TITLE
Feature/add redis db param

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,8 +1,0 @@
-The Open Government Licence (OGL) Version 3
-
-Copyright (c) 2020 DEFRA
-
-This source code is licensed under the Open Government Licence v3.0. To view this
-licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
-or write to the Information Policy Team, The National Archives, Kew, Richmond,
-Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -18,4 +18,3 @@ rpm run docker:stop
 
 - http://localhost:3000/openapi-ui
 - http://localhost:4000/hello
-- s

--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ rpm run docker:stop
 
 - http://localhost:3000/openapi-ui
 - http://localhost:4000/hello
+- s

--- a/packages/connectors-lib/src/config.js
+++ b/packages/connectors-lib/src/config.js
@@ -18,6 +18,7 @@ export default {
   },
   redis: {
     host: process.env.REDIS_HOST,
-    port: process.env.REDIS_PORT
+    port: process.env.REDIS_PORT,
+    database: process.env.REDIS_DATABASE
   }
 }

--- a/packages/connectors-lib/src/redis.js
+++ b/packages/connectors-lib/src/redis.js
@@ -6,12 +6,16 @@ let client
 export const REDIS = {
   getClient: () => client,
   initialiseConnection: async () => {
-    client = createClient({
+    client = createClient(Object.assign({
       socket: {
         host: Config.redis.host,
         port: Config.redis.port
       }
-    })
+    }, Config.redis.database
+      ? {
+          database: Config.redis.database
+        }
+      : {}))
     await client.connect()
     return Promise.resolve()
   }


### PR DESCRIPTION
Optional parameter, so that the API & other micro-services can use a different db within the same instance