### PR TITLE
Add username and query handlers

### DIFF
--- a/packages/api/openapi/licence.yaml
+++ b/packages/api/openapi/licence.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/user'
+        400:
+          description: Bad request. Username required
         500:
           description: Unexpected error on server
           content:
@@ -97,6 +99,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+
+  '/users':
+    get:
+      description: Get users
+      summary: Get the users and optionally filter by name
+      operationId: getUsers
+      parameters:
+        - in: query
+          name: username
+          required: false
+          schema:
+            type: string
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/users'
+        500:
+          description: Unexpected error on server
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+
 
 ################################################################################################
 # Applications
@@ -1111,12 +1139,24 @@ components:
 # Schemas
 ################################################################################################
   schemas:
+    users:
+      type: array
+      items:
+        $ref: '#/components/schemas/user'
+
     user:
       type: object
       additionalProperties: false
+      required:
+        - username
       properties:
         id:
           $ref: '#/components/schemas/uuid'
+        username:
+          type: string
+          minLength: 1
+          maxLength: 20
+          pattern: ^[A-Za-z0-9\s]*$
         createdAt:
           $ref: '#/components/schemas/timestamp'
         updatedAt:

--- a/packages/api/src/handlers/user/__tests__/delete-user.spec.js
+++ b/packages/api/src/handlers/user/__tests__/delete-user.spec.js
@@ -2,7 +2,7 @@
  * Mock the hapi request object
  */
 const uuid = '1e470963-e8bf-41f5-9b0b-52d19c21cb75'
-const path = 'user/uuid'
+const path = `/user/${uuid}`
 const req = { path }
 
 /*
@@ -32,12 +32,15 @@ describe('The deleteUser handler', () => {
 
   it('returns a 204 on successful delete', async () => {
     cache.delete = jest.fn()
+    cache.keys = jest.fn(() => ['random'])
     models.users = { destroy: jest.fn(() => 1) }
     models.applications = { findAll: jest.fn(() => []) }
     models.sites = { findAll: jest.fn(() => []) }
     await deleteUser(context, req, h)
     expect(models.users.destroy).toHaveBeenCalledWith({ where: { id: uuid } })
     expect(cache.delete).toHaveBeenCalledWith(req.path)
+    expect(cache.delete).toHaveBeenCalledWith('/users')
+    expect(cache.delete).toHaveBeenCalledWith('random')
     expect(codeFunc).toHaveBeenCalledWith(204)
   })
 

--- a/packages/api/src/handlers/user/__tests__/get-users.spec.js
+++ b/packages/api/src/handlers/user/__tests__/get-users.spec.js
@@ -1,0 +1,80 @@
+/*
+ * Mock the hapi request object
+ */
+
+/*
+ * Mock the hapi response toolkit in order to test the results of the request
+ */
+const codeFunc = jest.fn()
+const typeFunc = jest.fn(() => ({ code: codeFunc }))
+const h = { response: jest.fn(() => ({ type: typeFunc, code: codeFunc })) }
+
+/*
+ * Create the parameters and payload to mock the openApi context which is inserted into each handler
+ */
+const context = { request: {} }
+
+jest.mock('@defra/wls-database-model')
+
+let models
+let getUsers
+let cache
+
+const ts = {
+  createdAt: { toISOString: () => '2021-12-07T09:50:04.666Z' },
+  updatedAt: { toISOString: () => '2021-12-07T09:50:04.666Z' }
+}
+
+const tsR = {
+  createdAt: ts.createdAt.toISOString(),
+  updatedAt: ts.updatedAt.toISOString()
+}
+
+const applicationJson = 'application/json'
+describe('The getUsers handler', () => {
+  beforeAll(async () => {
+    models = (await import('@defra/wls-database-model')).models
+    cache = (await import('../../../services/cache.js')).cache
+    getUsers = (await import('../get-users.js')).default
+  })
+
+  it('returns the users and status 200 the cache', async () => {
+    cache.restore = jest.fn(() => JSON.stringify([{ foo: 'bar' }]))
+    await getUsers(context, { query: null, path: '/users' }, h)
+    expect(h.response).toHaveBeenCalledWith([{ foo: 'bar' }])
+    expect(typeFunc).toHaveBeenCalledWith(applicationJson)
+    expect(codeFunc).toHaveBeenCalledWith(200)
+  })
+
+  it('returns the users and status 200 the database', async () => {
+    cache.restore = jest.fn(() => null)
+    cache.save = jest.fn(() => null)
+    models.users = { findAll: jest.fn(() => ([{ dataValues: { username: 'Graham', ...ts } }])) }
+    await getUsers(context, { query: null, path: '/users' }, h)
+    expect(cache.save).toHaveBeenCalledWith('/users', [{ username: 'Graham', ...tsR }])
+    expect(models.users.findAll).toHaveBeenCalled()
+    expect(h.response).toHaveBeenCalledWith([{ username: 'Graham', ...tsR }])
+    expect(typeFunc).toHaveBeenCalledWith(applicationJson)
+    expect(codeFunc).toHaveBeenCalledWith(200)
+  })
+
+  it('returns a singleton array of users and status 200 the database', async () => {
+    cache.restore = jest.fn(() => null)
+    cache.save = jest.fn(() => null)
+    models.users = { findAll: jest.fn(() => ([{ dataValues: { username: 'Graham', ...ts } }])) }
+    await getUsers(context, { query: { username: 'Graham' }, path: '/users' }, h)
+    expect(cache.save).toHaveBeenCalledWith('/users?username=Graham', [{ username: 'Graham', ...tsR }])
+    expect(models.users.findAll).toHaveBeenCalledWith({ where: { username: 'Graham' } })
+    expect(h.response).toHaveBeenCalledWith([{ username: 'Graham', ...tsR }])
+    expect(typeFunc).toHaveBeenCalledWith(applicationJson)
+    expect(codeFunc).toHaveBeenCalledWith(200)
+  })
+
+  it('throws on an unexpected database error', async () => {
+    cache.restore = jest.fn(() => null)
+    models.users = { findAll: jest.fn(() => { throw new Error() }) }
+    await expect(async () => {
+      await getUsers(context, { query: null, path: '/users' }, h)
+    }).rejects.toThrow()
+  })
+})

--- a/packages/api/src/handlers/user/delete-user.js
+++ b/packages/api/src/handlers/user/delete-user.js
@@ -1,5 +1,5 @@
-import { cache } from '../../services/cache.js'
 import { models } from '@defra/wls-database-model'
+import { clearCaches } from './users-cache.js'
 
 export default async (context, req, h) => {
   const userId = context.request.params.userId
@@ -26,14 +26,14 @@ export default async (context, req, h) => {
     return h.response().code(409)
   }
 
-  // Ok to proceed with the delete
-  await cache.delete(req.path)
   const count = await models.users.destroy({
     where: {
       id: userId
     }
   })
+
   if (count === 1) {
+    await clearCaches(userId)
     // Return no content
     return h.response().code(204)
   } else {

--- a/packages/api/src/handlers/user/get-users.js
+++ b/packages/api/src/handlers/user/get-users.js
@@ -1,0 +1,42 @@
+import { models } from '@defra/wls-database-model'
+import { APPLICATION_JSON } from '../../constants.js'
+import { prepareResponse } from './user-proc.js'
+import { cache } from '../../services/cache.js'
+
+export default async (context, req, h) => {
+  try {
+    const params = new URLSearchParams(req.query)
+    const key = params.toString().length ? `${req.path}?${params.toString()}` : req.path
+    const saved = await cache.restore(key)
+
+    if (saved) {
+      return h.response(JSON.parse(saved))
+        .type(APPLICATION_JSON)
+        .code(200)
+    }
+
+    let users
+    if (req.query?.username) {
+      const username = req.query.username.trim().replace(/\s{2,}/g, ' ')
+      users = await models.users.findAll({
+        where: { username }
+      })
+    } else {
+      users = await models.users.findAll()
+    }
+
+    const response = users.map(u => prepareResponse(u.dataValues))
+
+    // Only cache non-zero results
+    if (response.length) {
+      await cache.save(key, response)
+    }
+
+    return h.response(response)
+      .type(APPLICATION_JSON)
+      .code(200)
+  } catch (err) {
+    console.error('Error inserting into USERS table', err)
+    throw new Error(err.message)
+  }
+}

--- a/packages/api/src/handlers/user/post-user.js
+++ b/packages/api/src/handlers/user/post-user.js
@@ -9,8 +9,23 @@ import { prepareResponse } from './user-proc.js'
  */
 export default async (context, req, h) => {
   try {
+    // Trim and remove multiple spaces
+    const username = req.payload.username.trim().replace(/\s{2,}/g, ' ')
+
+    // Ensure the username is not taken
+    const users = await models.users.findAll({
+      where: { username }
+    })
+
+    if (users.length) {
+      return h.response({ code: 400, error: { description: `username: '${username}' already exists` } })
+        .type(APPLICATION_JSON)
+        .code(400)
+    }
+
     const user = await models.users.create({
-      id: uuidv4()
+      id: uuidv4(),
+      username
     })
 
     const response = prepareResponse(user.dataValues)

--- a/packages/api/src/handlers/user/user.js
+++ b/packages/api/src/handlers/user/user.js
@@ -1,5 +1,6 @@
 import getUserByUserId from './get-user-by-user-id.js'
+import getUsers from './get-users.js'
 import postUser from './post-user.js'
 import deleteUser from './delete-user.js'
 
-export { getUserByUserId, deleteUser, postUser }
+export { getUserByUserId, getUsers, deleteUser, postUser }

--- a/packages/api/src/handlers/user/users-cache.js
+++ b/packages/api/src/handlers/user/users-cache.js
@@ -1,0 +1,8 @@
+import { cache } from '../../services/cache.js'
+
+export const clearCaches = async userId => {
+  await cache.delete(`/user/${userId}`)
+  await cache.delete('/users')
+  const keys = await cache.keys('/users?*')
+  await Promise.all(keys.map(async k => await cache.delete(k)))
+}

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -3,6 +3,7 @@ import Inert from '@hapi/inert'
 import { SERVER_PORT } from './constants.js'
 import {
   getUserByUserId,
+  getUsers,
   deleteUser,
   postUser
 } from './handlers/user/user.js'
@@ -70,6 +71,7 @@ const createServer = async () => new Hapi.Server({ port: SERVER_PORT })
 // Split out to comply with sonar-cube line restriction on functions
 const handlers = {
   getUserByUserId,
+  getUsers,
   postUser,
   deleteUser,
   getSitesByUserId,

--- a/packages/api/src/services/__tests__/cache.spec.js
+++ b/packages/api/src/services/__tests__/cache.spec.js
@@ -4,22 +4,25 @@ const so = { foo: 'bar' }
 const mockSet = jest.fn().mockImplementation(() => {})
 const mockGet = jest.fn().mockImplementation(() => {})
 const mockDel = jest.fn().mockImplementation(() => {})
+const mockKeys = jest.fn().mockImplementation(() => [])
 
 jest.mock('@defra/wls-connectors-lib', () => ({
   REDIS: {
     getClient: () => ({
       set: mockSet,
       get: mockGet,
-      GETDEL: mockDel
+      GETDEL: mockDel,
+      KEYS: mockKeys
     })
   }
 }))
 
 describe('Caching', () => {
-  it('the save and restore cache functions are called correctly', async () => {
+  it('the save, restore, delete and keys cache functions are called correctly', async () => {
     await cache.save('key', so)
     await cache.restore('key')
     await cache.delete('key')
+    await cache.keys('str')
     expect(mockSet).toHaveBeenCalledWith('key', JSON.stringify(so), {
       EX: 600
     })
@@ -27,5 +30,6 @@ describe('Caching', () => {
       EX: 600
     })
     expect(mockDel).toHaveBeenCalledWith('key')
+    expect(mockKeys).toHaveBeenCalledWith('str')
   })
 })

--- a/packages/api/src/services/cache.js
+++ b/packages/api/src/services/cache.js
@@ -17,5 +17,9 @@ export const cache = {
   delete: async key => {
     const client = REDIS.getClient()
     await client.GETDEL(key)
+  },
+  keys: async str => {
+    const client = REDIS.getClient()
+    return client.KEYS(str)
   }
 }

--- a/packages/database-model/src/sequelize-model.js
+++ b/packages/database-model/src/sequelize-model.js
@@ -6,9 +6,13 @@ const models = {}
 
 async function defineUsers (sequelize) {
   models.users = await sequelize.define('user', {
-    id: { type: DataTypes.UUID, primaryKey: true }
+    id: { type: DataTypes.UUID, primaryKey: true },
+    username: { type: DataTypes.STRING(20), allowNull: false }
   }, {
-    timestamps: true
+    timestamps: true,
+    indexes: [
+      { unique: true, fields: ['username'], name: 'user_username_uk' }
+    ]
   })
 }
 


### PR DESCRIPTION
Add handlers to set and get by username
Username is string with letters, numbers and spaces. It is max 30, trimmed and double spaces are removed.
When POST /user set
```
{
  "username": "Frank Bruno"
}
```
400 on duplicate

The handler for fetch is
/users
and 
/users?username=Frank%20Bruno

Misses give []