### PR TITLE
chore: bump docker swarm dependencies

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-api",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"@aws-sdk/client-secrets-manager": "^3.42.0",

--- a/packages/application-extract-processor/package-lock.json
+++ b/packages/application-extract-processor/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-application-extract-processor",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"debug": "^4.3.3",

--- a/packages/application-queue-processor/package-lock.json
+++ b/packages/application-queue-processor/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-application-queue-processor",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"debug": "^4.3.3",

--- a/packages/connectors-lib/package-lock.json
+++ b/packages/connectors-lib/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-connectors-lib",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.42.0",

--- a/packages/database-model/package-lock.json
+++ b/packages/database-model/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-database-model",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"debug": "^4.3.3"

--- a/packages/powerapps-lib/package-lock.json
+++ b/packages/powerapps-lib/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-powerapps-lib",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"lodash.clonedeep": "^4.5.0",

--- a/packages/queue-defs/package-lock.json
+++ b/packages/queue-defs/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-queue-defs",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"bull": "^4.1.1"

--- a/packages/refdata-extract-processor/package-lock.json
+++ b/packages/refdata-extract-processor/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-refdata-extract-processor",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"debug": "^4.3.3",

--- a/packages/web-service/package-lock.json
+++ b/packages/web-service/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@defra/wls-eps-web-service",
-			"version": "2.2.5-alpha.0",
+			"version": "2.2.7-alpha.0",
 			"license": "SEE LICENSE IN LICENCE",
 			"dependencies": {
 				"@hapi/boom": "^9.1.4",


### PR DESCRIPTION
When me and Sam run `npm run docker:start` the versions of the containers in the docker swarm is mismatched in our codebase

Docker  then pulls and updates the code, I just thought it would be useful to make a chore pr to bump our dependencies