### PR TITLE
Fix problem in eligibility routiong logic

### DIFF
--- a/packages/web-service/src/pages/eligibility/__tests__/eligibility.spec.js
+++ b/packages/web-service/src/pages/eligibility/__tests__/eligibility.spec.js
@@ -335,10 +335,61 @@ describe('the eligibility pages', () => {
       })
   })
 
-  it('the checkYourAnswersCompletion function always returns the eligible page', async () => {
+  it('the checkYourAnswersCompletion function returns the eligible page if the answers are consistent', async () => {
+    const request = { cache: () => ({ getData: jest.fn(() => ({ applicationId: '6829ad54-bab7-4a78-8ca9-dcf722117a45' })) }) }
+    jest.doMock('../../../services/api-requests.js', () => ({
+      APIRequests: {
+        ELIGIBILITY: {
+          getById: jest.fn(() => ({
+            permissionsGranted: true,
+            isOwnerOfLand: false,
+            hasLandOwnerPermission: true,
+            permissionsRequired: true
+          }))
+        }
+      }
+    }))
     const { checkAnswersCompletion } = await import('../eligibility.js')
-    const result = checkAnswersCompletion()
+    const result = await checkAnswersCompletion(request)
     expect(result).toEqual(ELIGIBLE.uri)
+  })
+
+  it('the checkYourAnswersCompletion function redirects to the not eligible landowner dropout', async () => {
+    const request = { cache: () => ({ getData: jest.fn(() => ({ applicationId: '6829ad54-bab7-4a78-8ca9-dcf722117a45' })) }) }
+    jest.doMock('../../../services/api-requests.js', () => ({
+      APIRequests: {
+        ELIGIBILITY: {
+          getById: jest.fn(() => ({
+            permissionsGranted: true,
+            isOwnerOfLand: false,
+            hasLandOwnerPermission: false,
+            permissionsRequired: true
+          }))
+        }
+      }
+    }))
+    const { checkAnswersCompletion } = await import('../eligibility.js')
+    const result = await checkAnswersCompletion(request)
+    expect(result).toEqual(NOT_ELIGIBLE_LANDOWNER.uri)
+  })
+
+  it('the checkYourAnswersCompletion function redirects to the not eligible permissions dropout', async () => {
+    const request = { cache: () => ({ getData: jest.fn(() => ({ applicationId: '6829ad54-bab7-4a78-8ca9-dcf722117a45' })) }) }
+    jest.doMock('../../../services/api-requests.js', () => ({
+      APIRequests: {
+        ELIGIBILITY: {
+          getById: jest.fn(() => ({
+            permissionsGranted: false,
+            isOwnerOfLand: false,
+            hasLandOwnerPermission: true,
+            permissionsRequired: true
+          }))
+        }
+      }
+    }))
+    const { checkAnswersCompletion } = await import('../eligibility.js')
+    const result = await checkAnswersCompletion(request)
+    expect(result).toEqual(NOT_ELIGIBLE_PROJECT.uri)
   })
 
   describe('the eligibleCheckData function', () => {

--- a/packages/web-service/src/pages/eligibility/eligibility.js
+++ b/packages/web-service/src/pages/eligibility/eligibility.js
@@ -163,7 +163,11 @@ export const checkYourAnswersSetData = async request => {
   await APIRequests.ELIGIBILITY.putById(journeyData.applicationId, eligibility)
 }
 
-export const checkAnswersCompletion = () => ELIGIBLE.uri
+export const checkAnswersCompletion = async request => {
+  // Rerun the general completion router to check all the answers are still Ok
+  const result = await eligibilityCompletion(request)
+  return result === ELIGIBILITY_CHECK.uri ? ELIGIBLE.uri : result
+}
 
 export const eligibilityCheck = checkAnswersPage(
   ELIGIBILITY_CHECK,


### PR DESCRIPTION
Routing logic error. By using the back button it is possible to confound the eligibility routing logic. (Re)apply the logic used in the section routing to the check page completion