### PR TITLE
docs: add the rest of the secrets ignore git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ Edit the .env files to add secrets
 
 If you receive the secrets, please remember to ignore them in git, by running  
 `git update-index --assume-unchanged docker/env/aqp-secrets.env`
+`git update-index --assume-unchanged docker/env/aep-secrets.env`
+`git update-index --assume-unchanged docker/env/aep.env`
+`git update-index --assume-unchanged docker/env/api.env`
+`git update-index --assume-unchanged docker/env/aqp.env`
+`git update-index --assume-unchanged docker/env/rep-secrets.env`
+`git update-index --assume-unchanged docker/env/rep.env`
+`git update-index --assume-unchanged docker/env/web-secrets.env`
 
 Alternatively set the environment variables in the running shell or your IDE
 


### PR DESCRIPTION
Added the rest of the secrets ignore commands, to ensure we don't ever accidently commit secrets files