### PR TITLE
Clam fail fast

### DIFF
--- a/packages/web-service/src/__tests__/web-service.spec.js
+++ b/packages/web-service/src/__tests__/web-service.spec.js
@@ -3,17 +3,18 @@ describe('The wrapper: web-service', () => {
     jest.isolateModules(() => {
       try {
         jest.mock('../server.js')
-        jest.mock('clamscan', () => jest.fn().mockImplementation(() => {
-          return ({ init: () => Promise.resolve() })
-        }))
+        jest.mock('../services/virus-scan.js')
         const { REDIS } = require('@defra/wls-connectors-lib')
         REDIS.initialiseConnection = jest.fn(() => Promise.resolve())
         const { createServer, init } = require('../server.js')
         createServer.mockImplementation(() => Promise.resolve())
         init.mockImplementation(() => Promise.resolve())
+        const { initializeClamScan } = require('../services/virus-scan.js')
+        initializeClamScan.mockImplementation(() => Promise.resolve())
 
         require('../web-service')
         setImmediate(() => {
+          expect(initializeClamScan).toHaveBeenCalled()
           expect(createServer).toHaveBeenCalled()
           expect(init).toHaveBeenCalled()
           done()
@@ -28,14 +29,15 @@ describe('The wrapper: web-service', () => {
     jest.isolateModules(() => {
       try {
         jest.mock('../server.js')
-        jest.mock('clamscan', () => jest.fn().mockImplementation(() => {
-          return ({ init: () => Promise.resolve() })
-        }))
+        jest.mock('../services/virus-scan.js')
         const { REDIS } = require('@defra/wls-connectors-lib')
         REDIS.initialiseConnection = jest.fn(() => Promise.resolve())
         const { createServer, init } = require('../server.js')
         createServer.mockImplementation(() => Promise.resolve())
         init.mockImplementation(() => Promise.reject(new Error()))
+        const { initializeClamScan } = require('../services/virus-scan.js')
+        initializeClamScan.mockImplementation(() => Promise.resolve())
+
         const processExitSpy = jest
           .spyOn(process, 'exit')
           .mockImplementation(code => {})

--- a/packages/web-service/src/services/__tests__/virus-scan.spec.js
+++ b/packages/web-service/src/services/__tests__/virus-scan.spec.js
@@ -1,9 +1,38 @@
 
 describe('The virus scanning service', () => {
   beforeEach(() => jest.resetModules())
+  describe('The clam initialization', () => {
+    it('resolves when initialized', async () => {
+      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
+        init: () => Promise.resolve()
+      })))
+      const { initializeClamScan } = await import('../virus-scan.js')
+      await expect(() => initializeClamScan()).resolves
+    })
+    it('rejects when initialization fails', async () => {
+      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
+        init: () => Promise.reject(new Error())
+      })))
+      const { initializeClamScan } = await import('../virus-scan.js')
+      await expect(() => initializeClamScan()).rejects.toThrow()
+    })
+  })
 
   describe('Scan file request', () => {
-    it('returns a boolean when initialised successfully', async () => {
+    it('returns a true and unlinks when scanned infected file', async () => {
+      const mockScan = { isInfected: true }
+      const mockUnlinkSync = jest.fn()
+      jest.doMock('fs', () => ({ unlinkSync: mockUnlinkSync }))
+      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
+        init: () => Promise.resolve({ isInfected: () => mockScan })
+      })))
+      const { scanFile, initializeClamScan } = await import('../virus-scan.js')
+      await initializeClamScan()
+      expect(await scanFile('text.txt')).toBe(true)
+      await expect(mockUnlinkSync).toHaveBeenCalledWith('text.txt')
+    })
+
+    it('returns a false when scanned clean file', async () => {
       const mockScan = { isInfected: false }
       jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
         init: () => Promise.resolve({ isInfected: () => mockScan })
@@ -22,7 +51,7 @@ describe('The virus scanning service', () => {
       const { scanFile, initializeClamScan } = await import('../virus-scan.js')
       await initializeClamScan()
       await expect(() => scanFile('text.txt')).rejects.toThrowError()
-      await expect(mockUnlinkSync).toHaveBeenCalledTimes(1)
+      await expect(mockUnlinkSync).toHaveBeenCalledWith('text.txt')
     })
   })
 })

--- a/packages/web-service/src/services/__tests__/virus-scan.spec.js
+++ b/packages/web-service/src/services/__tests__/virus-scan.spec.js
@@ -4,7 +4,7 @@ describe('The virus scanning service', () => {
   describe('The clam initialization', () => {
     it('resolves when initialized', async () => {
       jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
-        init: () => Promise.resolve()
+        init: () => Promise.resolve({ initialized: true })
       })))
       const { initializeClamScan } = await import('../virus-scan.js')
       await expect(() => initializeClamScan()).resolves
@@ -12,6 +12,13 @@ describe('The virus scanning service', () => {
     it('rejects when initialization fails', async () => {
       jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
         init: () => Promise.reject(new Error())
+      })))
+      const { initializeClamScan } = await import('../virus-scan.js')
+      await expect(() => initializeClamScan()).rejects.toThrow()
+    })
+    it('rejects when uninitialized fails', async () => {
+      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
+        init: () => Promise.resolve({ initialized: false })
       })))
       const { initializeClamScan } = await import('../virus-scan.js')
       await expect(() => initializeClamScan()).rejects.toThrow()
@@ -24,7 +31,7 @@ describe('The virus scanning service', () => {
       const mockUnlinkSync = jest.fn()
       jest.doMock('fs', () => ({ unlinkSync: mockUnlinkSync }))
       jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
-        init: () => Promise.resolve({ isInfected: () => mockScan })
+        init: () => Promise.resolve({ isInfected: () => mockScan, initialized: true })
       })))
       const { scanFile, initializeClamScan } = await import('../virus-scan.js')
       await initializeClamScan()
@@ -35,7 +42,7 @@ describe('The virus scanning service', () => {
     it('returns a false when scanned clean file', async () => {
       const mockScan = { isInfected: false }
       jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
-        init: () => Promise.resolve({ isInfected: () => mockScan })
+        init: () => Promise.resolve({ isInfected: () => mockScan, initialized: true })
       })))
       const { scanFile, initializeClamScan } = await import('../virus-scan.js')
       await initializeClamScan()
@@ -45,7 +52,7 @@ describe('The virus scanning service', () => {
     it('throws error and deletes file when clamscan fails', async () => {
       const mockUnlinkSync = jest.fn()
       jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
-        init: () => Promise.resolve({ isInfected: () => { throw new Error() } })
+        init: () => Promise.resolve({ isInfected: () => { throw new Error() }, initialized: true })
       })))
       jest.doMock('fs', () => ({ unlinkSync: mockUnlinkSync }))
       const { scanFile, initializeClamScan } = await import('../virus-scan.js')

--- a/packages/web-service/src/services/__tests__/virus-scan.spec.js
+++ b/packages/web-service/src/services/__tests__/virus-scan.spec.js
@@ -5,49 +5,24 @@ describe('The virus scanning service', () => {
   describe('Scan file request', () => {
     it('returns a boolean when initialised successfully', async () => {
       const mockScan = { isInfected: false }
-      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => {
-        return ({ init: () => Promise.resolve({ isInfected: () => mockScan }) })
-      })
-      )
-      const { scanFile } = await import('../virus-scan.js')
+      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
+        init: () => Promise.resolve({ isInfected: () => mockScan })
+      })))
+      const { scanFile, initializeClamScan } = await import('../virus-scan.js')
+      await initializeClamScan()
       expect(await scanFile('text.txt')).toBe(false)
     })
+
     it('throws error and deletes file when clamscan fails', async () => {
-      const mockNull = jest.fn((filename, callback) => callback(null))
-      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => {
-        return ({ init: () => Promise.resolve({ isInfected: () => { throw new Error() } }) })
-      })
-      )
-      jest.doMock('fs', () => ({ unlinkSync: mockNull }))
-      const { scanFile } = await import('../virus-scan.js')
+      const mockUnlinkSync = jest.fn()
+      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => ({
+        init: () => Promise.resolve({ isInfected: () => { throw new Error() } })
+      })))
+      jest.doMock('fs', () => ({ unlinkSync: mockUnlinkSync }))
+      const { scanFile, initializeClamScan } = await import('../virus-scan.js')
+      await initializeClamScan()
       await expect(() => scanFile('text.txt')).rejects.toThrowError()
-      await expect(mockNull).toHaveBeenCalledTimes(1)
-    })
-    it('throws an error if file could not be deleted', async () => {
-      const mockScan = { isInfected: true }
-      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => {
-        return ({ init: () => Promise.resolve({ isInfected: () => mockScan }) })
-      })
-      )
-      const mockError = jest.fn((filename, callback) => callback(new Error('the file could not be deleted.')))
-      jest.doMock('fs', () => ({ unlinkSync: mockError }))
-      const logSpy = jest.spyOn(console, 'log')
-      const { scanFile } = await import('../virus-scan.js')
-      await expect(async () => await scanFile('text.txt')).rejects.toThrowError('the file could not be deleted.')
-      await expect(logSpy).toHaveBeenCalledTimes(0)
-    })
-    it('deletes the file successfully', async () => {
-      const mockScan = { isInfected: true }
-      jest.doMock('clamscan', () => jest.fn().mockImplementation(() => {
-        return ({ init: () => Promise.resolve({ isInfected: () => mockScan }) })
-      })
-      )
-      const mockNull = jest.fn((filename, callback) => callback(null))
-      jest.doMock('fs', () => ({ unlinkSync: mockNull }))
-      const { scanFile } = await import('../virus-scan.js')
-      const logSpy = jest.spyOn(console, 'log')
-      await scanFile('text.txt')
-      await expect(logSpy).toHaveBeenCalledWith('The file contained a virus, so it was deleted.')
+      await expect(mockUnlinkSync).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/web-service/src/services/virus-scan.js
+++ b/packages/web-service/src/services/virus-scan.js
@@ -22,7 +22,8 @@ export const initializeClamScan = async () => {
     if (clamScan.initialized) {
       console.log('clam virus scanner container is initialized')
     } else {
-      console.log('Clam virus scanner container is not initialized')
+      console.error('Clam virus scanner container is not initialized')
+      return Promise.reject(new Error(`Error initializing clam. Options: ${JSON.stringify(options)}`))
     }
     return Promise.resolve()
   } catch (err) {

--- a/packages/web-service/src/services/virus-scan.js
+++ b/packages/web-service/src/services/virus-scan.js
@@ -12,32 +12,35 @@ const options = {
   },
   preference: 'clamdscan'
 }
-const ClamScan = new NodeClam().init(options)
+
+let clamScan
+
+export const initializeClamScan = async () => {
+  try {
+    const cs = new NodeClam()
+    clamScan = await cs.init(options)
+    if (clamScan.initialized) {
+      console.log('clam virus scanner container is initialized')
+    } else {
+      console.log('Clam virus scanner container is not initialized')
+    }
+    return Promise.resolve()
+  } catch (err) {
+    console.error(err)
+    return Promise.reject(new Error(`Error initializing clam. Options: ${JSON.stringify(options)}`))
+  }
+}
 
 export async function scanFile (filepath) {
-  return ClamScan.then(async clamscan => {
-    try {
-      const { isInfected } = await clamscan.isInfected(filepath)
-      if (isInfected) {
-        fs.unlinkSync(filepath, err => {
-          if (err) {
-            console.error(err)
-            throw err
-          }
-          console.log('The file contained a virus, so it was deleted.')
-        })
-      }
-      return isInfected
-    } catch (err) {
-      console.error(err.message)
-      fs.unlinkSync(filepath, delErr => {
-        if (delErr) {
-          console.error(delErr)
-          throw delErr
-        }
-      })
-      console.error(err.message)
-      throw new Error(err)
+  try {
+    const { isInfected } = await clamScan.isInfected(filepath)
+    if (isInfected) {
+      fs.unlinkSync(filepath)
     }
-  })
+    return isInfected
+  } catch (err) {
+    console.error(err.message)
+    fs.unlinkSync(filepath)
+    throw new Error(err)
+  }
 }

--- a/packages/web-service/src/web-service.js
+++ b/packages/web-service/src/web-service.js
@@ -1,11 +1,11 @@
 import { init, createServer } from './server.js'
+import { initializeClamScan } from './services/virus-scan.js'
 import { REDIS } from '@defra/wls-connectors-lib'
 
 REDIS.initialiseConnection()
-  .then(() => createServer()
-    .then(s =>
-      init(s).catch(e => {
+  .then(() => initializeClamScan()
+    .then(() => createServer()
+      .then(s => init(s).catch(e => {
         console.error(e)
         process.exit(1)
-      })
-    ))
+      }))))


### PR DESCRIPTION
(1) Make the front end fail immediately and report an error if the virus checker cannot initialise.
(2) See https://nodejs.org/api/fs.html#fsunlinksyncpath - the unlinksync function does NOT have a callback!
