### PR TITLE
Feature/cache fix and tags

### DIFF
--- a/packages/api/openapi/licence.yaml
+++ b/packages/api/openapi/licence.yaml
@@ -2208,8 +2208,6 @@ components:
           type: boolean
         permissionsGranted:
           type: boolean
-        checkCompleted:
-          type: boolean
 
     applicationAccounts:
       type: array

--- a/packages/api/openapi/licence.yaml
+++ b/packages/api/openapi/licence.yaml
@@ -2158,6 +2158,10 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/uuid'
+        applicationTags:
+          type: array
+          items:
+            type: string
         applicationReferenceNumber:
           type: string
           minLength: 13

--- a/packages/web-service/src/pages/eligibility/__tests__/eligibility.spec.js
+++ b/packages/web-service/src/pages/eligibility/__tests__/eligibility.spec.js
@@ -35,12 +35,15 @@ describe('the eligibility pages', () => {
         ELIGIBILITY: {
           getById: jest.fn(() => ({ question: 'answer' })),
           putById: mockPut
+        },
+        APPLICATION: {
+          tags: () => ({ remove: jest.fn() })
         }
       }
     }))
     const { getData } = await import('../eligibility.js')
     const result = await getData('question')(request)
-    expect(mockPut).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', { checkCompleted: false })
+    expect(mockPut).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', { })
     expect(result).toBeNull()
   })
 
@@ -62,12 +65,15 @@ describe('the eligibility pages', () => {
           ELIGIBILITY: {
             getById: jest.fn(() => ({ isOwnerOfLand: false })),
             putById: mockPutById
+          },
+          APPLICATION: {
+            tags: () => ({ remove: jest.fn() })
           }
         }
       }))
       const { setData } = await import('../eligibility.js')
       await setData('hasLandOwnerPermission')(request)
-      expect(mockPutById).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', { checkCompleted: false, hasLandOwnerPermission: true, isOwnerOfLand: false })
+      expect(mockPutById).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', { hasLandOwnerPermission: true, isOwnerOfLand: false })
       expect(mockClearPageData).toHaveBeenCalledWith('consent-granted')
     })
 
@@ -88,12 +94,15 @@ describe('the eligibility pages', () => {
           ELIGIBILITY: {
             getById: jest.fn(() => ({ isOwnerOfLand: true })),
             putById: mockPutById
+          },
+          APPLICATION: {
+            tags: () => ({ remove: jest.fn() })
           }
         }
       }))
       const { setData } = await import('../eligibility.js')
       await setData('hasLandOwnerPermission')(request)
-      expect(mockPutById).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', { checkCompleted: false, isOwnerOfLand: true })
+      expect(mockPutById).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', { isOwnerOfLand: true })
       expect(mockClearPageData).toHaveBeenCalledWith('consent-granted')
     })
 
@@ -114,13 +123,15 @@ describe('the eligibility pages', () => {
           ELIGIBILITY: {
             getById: jest.fn(() => ({ permissionsRequired: true })),
             putById: mockPutById
+          },
+          APPLICATION: {
+            tags: () => ({ remove: jest.fn() })
           }
         }
       }))
       const { setData } = await import('../eligibility.js')
       await setData('permissionsGranted')(request)
       expect(mockPutById).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', {
-        checkCompleted: false,
         permissionsRequired: true,
         permissionsGranted: true
       })
@@ -143,13 +154,15 @@ describe('the eligibility pages', () => {
           ELIGIBILITY: {
             getById: jest.fn(() => ({ permissionsRequired: false })),
             putById: mockPutById
+          },
+          APPLICATION: {
+            tags: () => ({ remove: jest.fn() })
           }
         }
       }))
       const { setData } = await import('../eligibility.js')
       await setData('permissionsGranted')(request)
       expect(mockPutById).toHaveBeenCalledWith('412d7297-643d-485b-8745-cc25a0e6ec0a', {
-        checkCompleted: false,
         permissionsRequired: false
       })
       expect(mockClearPageData).toHaveBeenCalledWith('consent-granted')
@@ -381,7 +394,7 @@ describe('the eligibility pages', () => {
 
   it('the checkYourAnswersSetData function sets the check completed flag', async () => {
     const request = { cache: () => ({ getData: jest.fn(() => ({ applicationId: '6829ad54-bab7-4a78-8ca9-dcf722117a45' })) }) }
-    const mockPutById = jest.fn()
+    const mockAdd = jest.fn()
     jest.doMock('../../../services/api-requests.js', () => ({
       APIRequests: {
         ELIGIBILITY: {
@@ -390,22 +403,16 @@ describe('the eligibility pages', () => {
             isOwnerOfLand: false,
             hasLandOwnerPermission: true,
             permissionsRequired: true
-          })),
-          putById: mockPutById
+          }))
+        },
+        APPLICATION: {
+          tags: () => ({ add: mockAdd })
         }
       }
     }))
-
     const { checkYourAnswersSetData } = await import('../eligibility.js')
     await checkYourAnswersSetData(request)
-    expect(mockPutById).toHaveBeenCalledWith('6829ad54-bab7-4a78-8ca9-dcf722117a45',
-      {
-        checkCompleted: true,
-        hasLandOwnerPermission: true,
-        isOwnerOfLand: false,
-        permissionsGranted: true,
-        permissionsRequired: true
-      })
+    expect(mockAdd).toHaveBeenCalledWith('eligibility-check')
   })
 
   it('the checkYourAnswersCompletion function returns the eligible page if the answers are consistent', async () => {

--- a/packages/web-service/src/pages/macros/answer-summary.njk
+++ b/packages/web-service/src/pages/macros/answer-summary.njk
@@ -10,7 +10,7 @@
             {% for item in checkData %}
                 {{ rows.push({
                     key: { text: questionMap[item.key].question },
-                    value: { text: questionMap[item.key].answer[item.value] },
+                    value: { text: questionMap[item.key].answer[item.value] if questionMap[item.key].answer else item.value },
                     actions: { items: [ { href: questionMap[item.key].href,
                                           text: "Change",
                                           classes: 'govuk-link govuk-link--no-visited-state',

--- a/packages/web-service/src/pages/tasklist/__tests__/licence-type-map.spec.js
+++ b/packages/web-service/src/pages/tasklist/__tests__/licence-type-map.spec.js
@@ -15,15 +15,12 @@ describe('The licence type map', () => {
         getData: () => ({ applicationId: '8a3e8c32-0138-402c-8913-87e78ed44ebd' })
       })
     }
-    const mockGetById = jest.fn(() => ({
-      eligibility: {
-        checkCompleted: true
-      }
-    }))
     jest.doMock('../../../services/api-requests.js', () => ({
       APIRequests: {
         APPLICATION: {
-          getById: mockGetById
+          getById: jest.fn(() => ({
+            applicationTags: ['eligibility-check']
+          }))
         }
       }
     }))

--- a/packages/web-service/src/pages/tasklist/licence-type-map.js
+++ b/packages/web-service/src/pages/tasklist/licence-type-map.js
@@ -1,5 +1,4 @@
 import { eligibilityURIs, contactURIs, DECLARATION, FILE_UPLOADS, habitatURIs } from '../../uris.js'
-import { CHECK_COMPLETED } from '../eligibility/eligibility.js'
 import { APIRequests } from '../../services/api-requests.js'
 
 const { LANDOWNER, ELIGIBILITY_CHECK } = eligibilityURIs
@@ -40,8 +39,9 @@ export const getProgress = status => ({
 export const getTaskStatus = async request => {
   const journeyData = await request.cache().getData()
   const application = await APIRequests.APPLICATION.getById(journeyData.applicationId)
+  const applicationTags = application.applicationTags || []
   return {
-    [SECTION_TASKS.ELIGIBILITY_CHECK]: application?.eligibility?.[CHECK_COMPLETED] || false,
+    [SECTION_TASKS.ELIGIBILITY_CHECK]: applicationTags.includes(SECTION_TASKS.ELIGIBILITY_CHECK),
     [SECTION_TASKS.LICENCE_HOLDER]: false,
     [SECTION_TASKS.ECOLOGIST]: false,
     [SECTION_TASKS.WORK_ACTIVITY]: false,

--- a/packages/web-service/src/services/__tests__/api-requests.spec.js
+++ b/packages/web-service/src/services/__tests__/api-requests.spec.js
@@ -359,6 +359,112 @@ describe('The API requests service', () => {
       await expect(() => APIRequests.APPLICATION.submit('b306c67f-f5cd-4e69-9986-8390188051b3', '9913c6c2-1cdf-4582-a591-92c058d0e07d'))
         .rejects.toThrowError()
     })
+
+    describe('the tag functions', () => {
+      it('the add tag function calls the the API correctly if tag present', async () => {
+        const mockPut = jest.fn()
+        const mockGet = jest.fn(() => ({ foo: 'bar', applicationTags: ['here-before'] }))
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            put: mockPut,
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        await APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').add('tag')
+        expect(mockPut).toHaveBeenCalledWith('/application/b306c67f-f5cd-4e69-9986-8390188051b3', {
+          applicationTags: expect.arrayContaining(['tag', 'here-before']), foo: 'bar'
+        })
+      })
+
+      it('the add tag function ignores duplicate tags', async () => {
+        const mockGet = jest.fn(() => ({ foo: 'bar', applicationTags: ['tag'] }))
+        const mockPut = jest.fn()
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            put: mockPut,
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        await APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').add('tag')
+        expect(mockPut).not.toHaveBeenCalledWith()
+      })
+
+      it('the add tag function rethrows an error', async () => {
+        const mockGet = jest.fn(() => { throw new Error() })
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        await expect(() => APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').add('tsg-2'))
+          .rejects.toThrowError()
+      })
+
+      it('the has tag function calls the the API correctly if tag present', async () => {
+        const mockGet = jest.fn(() => ({ foo: 'bar', applicationTags: ['tag'] }))
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        const result = await APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').has('tag')
+        expect(result).toBeTruthy()
+      })
+
+      it('the has tag function calls the the API correctly if tag not present', async () => {
+        const mockGet = jest.fn(() => ({ foo: 'bar', applicationTags: ['tag'] }))
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        const result = await APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').has('tag-2')
+        expect(result).not.toBeTruthy()
+      })
+
+      it('the has tag function rethrows an error', async () => {
+        const mockGet = jest.fn(() => { throw new Error() })
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        await expect(() => APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').has('tsg-2'))
+          .rejects.toThrowError()
+      })
+
+      it('the remove tag function calls the the API correctly if tag present', async () => {
+        const mockGet = jest.fn(() => ({ foo: 'bar', applicationTags: ['tag', 'tag-2'] }))
+        const mockPut = jest.fn()
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            get: mockGet,
+            put: mockPut
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        await APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').remove('tag-2')
+        expect(mockPut).toHaveBeenCalledWith('/application/b306c67f-f5cd-4e69-9986-8390188051b3', { applicationTags: ['tag'], foo: 'bar' })
+      })
+
+      it('the remove tag function rethrows an error', async () => {
+        const mockGet = jest.fn(() => { throw new Error() })
+        jest.doMock('@defra/wls-connectors-lib', () => ({
+          API: {
+            get: mockGet
+          }
+        }))
+        const { APIRequests } = await import('../api-requests.js')
+        await expect(() => APIRequests.APPLICATION.tags('b306c67f-f5cd-4e69-9986-8390188051b3').remove('tsg-2'))
+          .rejects.toThrowError()
+      })
+    })
   })
 
   describe('ELIGIBILITY requests', () => {

--- a/packages/web-service/src/services/api-requests.js
+++ b/packages/web-service/src/services/api-requests.js
@@ -322,7 +322,46 @@ export const APIRequests = {
         Boom.boomify(error, { statusCode: 500 })
         throw error
       }
-    }
+    },
+    tags: applicationId => ({
+      add: async tag => {
+        try {
+          const application = await API.get(`${apiUrls.APPLICATION}/${applicationId}`)
+          const applicationTags = application.applicationTags || []
+          if (!applicationTags.find(t => t === tag)) {
+            applicationTags.push(tag)
+            await API.put(`${apiUrls.APPLICATION}/${applicationId}`, application)
+          }
+        } catch (error) {
+          console.error(`Error adding tag ${tag} for applicationId: ${applicationId}`, error)
+          Boom.boomify(error, { statusCode: 500 })
+          throw error
+        }
+      },
+      has: async tag => {
+        try {
+          const application = await API.get(`${apiUrls.APPLICATION}/${applicationId}`)
+          const applicationTags = application.applicationTags || []
+          return applicationTags.find(t => t === tag)
+        } catch (error) {
+          console.error(`Error fetching tag ${tag} for applicationId: ${applicationId}`, error)
+          Boom.boomify(error, { statusCode: 500 })
+          throw error
+        }
+      },
+      remove: async tag => {
+        try {
+          const application = await API.get(`${apiUrls.APPLICATION}/${applicationId}`)
+          const applicationTags = application.applicationTags || []
+          Object.assign(application, { applicationTags: applicationTags.filter(t => t !== tag) })
+          await API.put(`${apiUrls.APPLICATION}/${applicationId}`, application)
+        } catch (error) {
+          console.error(`Error removing tag ${tag} for applicationId: ${applicationId}`, error)
+          Boom.boomify(error, { statusCode: 500 })
+          throw error
+        }
+      }
+    })
   },
   ELIGIBILITY: {
     getById: async applicationId => {

--- a/packages/web-service/src/session-cache/__tests__/cache-decorator.spec.js
+++ b/packages/web-service/src/session-cache/__tests__/cache-decorator.spec.js
@@ -93,4 +93,21 @@ describe('The cache-decorator', () => {
     const cacheDecorator = cd.default('sid')
     await expect(async () => await cacheDecorator.call({ state: { sid: null } })).rejects.toThrowError()
   })
+
+  describe('the cache direct function', () => {
+    it('gets the data from the cache using the context', async () => {
+      const mockRestore = jest.fn(() => JSON.stringify({ foo: 'bar' }))
+      jest.doMock('@defra/wls-connectors-lib', () => ({
+        REDIS: {
+          cache: {
+            restore: mockRestore
+          }
+        }
+      }))
+      const { cacheDirect } = await import('../cache-decorator.js')
+      const result = await cacheDirect({ context: { state: { sid: { id: 123 } } } }).getData()
+      expect(result).toEqual({ foo: 'bar' })
+      expect(mockRestore).toHaveBeenLastCalledWith('123_data')
+    })
+  })
 })


### PR DESCRIPTION
**// Ability to add status tags to the application**
const { applicationId } = await request.cache().getData()
await APIRequests.APPLICATION.tags(applicationId).add(‘tag-name’)
await APIRequests.APPLICATION.tags(applicationId).has(‘tag-name’)

True 

await APIRequests.APPLICATION.tags(applicationId).remove(‘tag-name’)
await APIRequests.APPLICATION.tags(applicationId).has(‘tag-name’)

False

See different use in tasklist type map

**// The ability to get the journey cache in validators**
 import { cacheDirect } from '../../../../session-cache/cache-decorator.js'

 import Joi from 'joi'

// The validator has a second argument of the contact which contains the state (session cookie object)
// This can only read the journey cache 
const validator = async (payload, context) => {
  const journeyData = await cacheDirect(context).getData()
  Joi.validate(…)
}
