### PR TITLE
fix: ensure scanning can be configured locally to be turned off

### DIFF
--- a/docker/env/web.env
+++ b/docker/env/web.env
@@ -20,6 +20,7 @@ REDIS_PORT=6379
 CS_HOST=host.docker.internal
 CS_PORT=3310
 CS_TIMEOUT=60000
+SCANNING_REQUIRED=true
 
 # Scanning directory
 SCANDIR=/scandir

--- a/packages/web-service/env.example
+++ b/packages/web-service/env.example
@@ -19,6 +19,7 @@ REDIS_PORT=6379
 CS_HOST=localhost
 CS_PORT=3310
 CS_TIMEOUT=60000
+SCANNING_REQUIRED=true
 
 # Scanning directory
 SCANDIR=/tmp

--- a/packages/web-service/src/services/__tests__/virus-scan.spec.js
+++ b/packages/web-service/src/services/__tests__/virus-scan.spec.js
@@ -14,6 +14,7 @@ describe('The virus scanning service', () => {
         init: () => Promise.reject(new Error())
       })))
       const { initializeClamScan } = await import('../virus-scan.js')
+      process.env.SCANNING_REQUIRED = true
       await expect(() => initializeClamScan()).rejects.toThrow()
     })
     it('rejects when uninitialized fails', async () => {

--- a/packages/web-service/src/services/virus-scan.js
+++ b/packages/web-service/src/services/virus-scan.js
@@ -34,6 +34,8 @@ export const initializeClamScan = async () => {
       return Promise.reject(new Error(`Error initializing clam. Options: ${JSON.stringify(options)}`))
     }
   }
+
+  return undefined
 }
 
 export async function scanFile (filepath) {

--- a/packages/web-service/src/services/virus-scan.js
+++ b/packages/web-service/src/services/virus-scan.js
@@ -16,19 +16,23 @@ const options = {
 let clamScan
 
 export const initializeClamScan = async () => {
-  try {
-    const cs = new NodeClam()
-    clamScan = await cs.init(options)
-    if (clamScan.initialized) {
-      console.log('clam virus scanner container is initialized')
-    } else {
-      console.error('Clam virus scanner container is not initialized')
+  // If you run an M1 based architecutre, the clamscan image doesn't currently work when developing locally
+  // env var makes it more configurable to just turn it off when debugging
+  if (process.env.SCANNING_REQUIRED) {
+    try {
+      const cs = new NodeClam()
+      clamScan = await cs.init(options)
+      if (clamScan.initialized) {
+        console.log('clam virus scanner container is initialized')
+      } else {
+        console.error('Clam virus scanner container is not initialized')
+        return Promise.reject(new Error(`Error initializing clam. Options: ${JSON.stringify(options)}`))
+      }
+      return Promise.resolve()
+    } catch (err) {
+      console.error(err)
       return Promise.reject(new Error(`Error initializing clam. Options: ${JSON.stringify(options)}`))
     }
-    return Promise.resolve()
-  } catch (err) {
-    console.error(err)
-    return Promise.reject(new Error(`Error initializing clam. Options: ${JSON.stringify(options)}`))
   }
 }
 


### PR DESCRIPTION
Had a discussion with Graham that it would be good if we could configure the scanning to be driven by an env var