### PR TITLE
fix: character count failing for sddsip:611

### DIFF
--- a/packages/web-service/src/pages/ecologist-experience/enter-experience/enter-experience.js
+++ b/packages/web-service/src/pages/ecologist-experience/enter-experience/enter-experience.js
@@ -33,7 +33,11 @@ export default pageRoute({
   page: ecologistExperienceURIs.ENTER_EXPERIENCE.page,
   checkData: checkApplication,
   validator: Joi.object({
-    'enter-experience': Joi.string().replace(/((\s+){2,})/gm, '$2').required().max(4000)
+    // JS post message here sends line breaks with \r\n (CRLF) but the Gov.uk prototypes counts newlines as \n
+    // Which leads to a mismatch on the character count as
+    // '\r\n'.length == 2
+    // '\n'.length   == 1
+    'enter-experience': Joi.string().required().replace('\r\n', '\n').max(4000)
   }).options({ abortEarly: false, allowUnknown: true }),
   setData,
   completion,

--- a/packages/web-service/src/pages/ecologist-experience/enter-methods/enter-methods.js
+++ b/packages/web-service/src/pages/ecologist-experience/enter-methods/enter-methods.js
@@ -33,7 +33,11 @@ export default pageRoute({
   page: ecologistExperienceURIs.ENTER_METHODS.page,
   checkData: checkApplication,
   validator: Joi.object({
-    'enter-methods': Joi.string().replace(/((\s+){2,})/gm, '$2').required().max(4000)
+    // JS post message here sends line breaks with \r\n (CRLF) but the Gov.uk prototypes counts newlines as \n
+    // Which leads to a mismatch on the character count as
+    // '\r\n'.length == 2
+    // '\n'.length   == 1
+    'enter-methods': Joi.string().required().replace('\r\n', '\n').max(4000)
   }).options({ abortEarly: false, allowUnknown: true }),
   setData,
   completion,


### PR DESCRIPTION
The post message was sending newlines with '/r/n' and was counting 2 characters