### PR TITLE
Fix: error on a page is not clearing out if user revisit the page and  improve file upload test coverage

### DIFF
--- a/packages/web-service/src/pages/site/select-address/__tests__/select-address.spec.js
+++ b/packages/web-service/src/pages/site/select-address/__tests__/select-address.spec.js
@@ -5,9 +5,11 @@ describe('site-got-postcode page handler', () => {
       siteData: { postcode: 'B15 7GF' },
       addressLookup: [{ Address: { town: 'Bristol' } }]
     }
+    const mockClearPageData = jest.fn()
     const request = {
       cache: () => ({
-        getData: () => result
+        getData: () => result,
+        clearPageData: mockClearPageData
       })
     }
 
@@ -17,6 +19,7 @@ describe('site-got-postcode page handler', () => {
       uri: { addressForm: '/site-address-no-lookup', postcode: '/site-got-postcode' },
       addressLookup: [{ Address: { town: 'Bristol' } }]
     })
+    expect(mockClearPageData).toHaveBeenCalledWith('select-address')
   })
 
   it('setData', async () => {

--- a/packages/web-service/src/pages/site/select-address/select-address.js
+++ b/packages/web-service/src/pages/site/select-address/select-address.js
@@ -6,6 +6,7 @@ import { mapLookedUpAddress } from '../../contact/common/address/address.js'
 
 export const getData = async request => {
   const journeyData = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.SELECT_ADDRESS.page)
   return {
     postcode: journeyData?.siteData?.postcode,
     uri: { addressForm: siteURIs.ADDRESS_NO_LOOKUP.uri, postcode: siteURIs.SITE_GOT_POSTCODE.uri },

--- a/packages/web-service/src/pages/site/site-address-no-lookup/__tests__/site-address-no-lookup.spec.js
+++ b/packages/web-service/src/pages/site/site-address-no-lookup/__tests__/site-address-no-lookup.spec.js
@@ -1,12 +1,17 @@
 describe('site-got-postcode page handler', () => {
   beforeEach(() => jest.resetModules())
   it('getData returns the correct object', async () => {
+    const mockClearPageData = jest.fn()
     const request = {
-      query: { postcode: 'B15 7GF' }
+      query: { postcode: 'B15 7GF' },
+      cache: () => ({
+        clearPageData: mockClearPageData
+      })
     }
 
     const { getData } = await import('../site-address-no-lookup.js')
     expect(await getData(request)).toStrictEqual({ postCode: true })
+    expect(mockClearPageData).toHaveBeenCalledWith('site-address-no-lookup')
   })
 
   it('setData', async () => {

--- a/packages/web-service/src/pages/site/site-address-no-lookup/site-address-no-lookup.js
+++ b/packages/web-service/src/pages/site/site-address-no-lookup/site-address-no-lookup.js
@@ -6,6 +6,7 @@ import { mapInputAddress } from '../../contact/common/address-form/address-form.
 import { ukPostcodeRegex } from '../../contact/common/postcode/postcode-page.js'
 
 export const getData = async request => {
+  await request.cache().clearPageData(siteURIs.ADDRESS_NO_LOOKUP.page)
   return { postCode: !request.query['no-postcode'] }
 }
 

--- a/packages/web-service/src/pages/site/site-check/__tests__/site-check.spec.js
+++ b/packages/web-service/src/pages/site/site-check/__tests__/site-check.spec.js
@@ -25,6 +25,7 @@ describe('The site address and National Grid Reference page', () => {
         }
       }
     }
+    const mockClearPageData = jest.fn()
 
     jest.doMock('../../../../services/api-requests.js', () => ({
       tagStatus: {
@@ -48,12 +49,14 @@ describe('The site address and National Grid Reference page', () => {
       cache: () => ({
         getData: () => {
           return result
-        }
+        },
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../site-check.js')
     expect(await getData(request)).toStrictEqual({ proximityFlag: true, siteAddress: 'site street, jubilee, 123, site street, Peckham, kent, SW1W 0NY', gridReference: 'NY123456' })
+    expect(mockClearPageData).toHaveBeenCalled()
   })
 
   it('should redirect user to check site answers page', async () => {

--- a/packages/web-service/src/pages/site/site-check/site-check.js
+++ b/packages/web-service/src/pages/site/site-check/site-check.js
@@ -26,6 +26,7 @@ export const completion = async request => {
 export const getData = async request => {
   const siteId = (await request.cache().getData())?.siteData?.id
   const site = await APIRequests.SITE.getSiteById(siteId)
+  await request.cache().clearPageData(siteURIs.SITE_CHECK.page)
   const { address, gridReference } = site
   const { xCoordinate, yCoordinate } = address
   const proximity = getGridReferenceProximity(gridReference, xCoordinate, yCoordinate)

--- a/packages/web-service/src/pages/site/site-got-postcode/__tests__/site-got-postcode.spec.js
+++ b/packages/web-service/src/pages/site/site-got-postcode/__tests__/site-got-postcode.spec.js
@@ -25,16 +25,19 @@ describe('site-got-postcode page handler', () => {
 
   it('getData returns the correct object', async () => {
     const result = { siteData: { postcode: 'B15 7GF' } }
+    const mockClearPageData = jest.fn()
     const request = {
       cache: () => ({
         getData: () => {
           return result
-        }
+        },
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../site-got-postcode.js')
     expect(await getData(request)).toStrictEqual({ sitePostcode: 'B15 7GF' })
+    expect(mockClearPageData).toHaveBeenCalledWith('site-got-postcode')
   })
 
   it('setData', async () => {

--- a/packages/web-service/src/pages/site/site-got-postcode/site-got-postcode.js
+++ b/packages/web-service/src/pages/site/site-got-postcode/site-got-postcode.js
@@ -23,6 +23,7 @@ export const validator = async payload => {
 
 export const getData = async request => {
   const { siteData } = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.SITE_GOT_POSTCODE.page)
   const { postcode } = siteData
   return { sitePostcode: postcode }
 }

--- a/packages/web-service/src/pages/site/site-grid-ref/__tests__/site-grid-ref.spec.js
+++ b/packages/web-service/src/pages/site/site-grid-ref/__tests__/site-grid-ref.spec.js
@@ -2,6 +2,7 @@ describe('The site national grid reference page', () => {
   beforeEach(() => jest.resetModules())
 
   it('getData returns the correct object', async () => {
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       tagStatus: {
         IN_PROGRESS: 'in-progress'
@@ -23,15 +24,18 @@ describe('The site national grid reference page', () => {
       cache: () => ({
         getData: () => {
           return {}
-        }
+        },
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../site-grid-ref.js')
     expect(await getData(request)).toStrictEqual({ gridReference: 'NY123456' })
+    expect(mockClearPageData).toHaveBeenCalledWith('site-grid-ref')
   })
 
   it('getData returns  undefined if not site found', async () => {
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       tagStatus: {
         IN_PROGRESS: 'in-progress'
@@ -53,15 +57,17 @@ describe('The site national grid reference page', () => {
       cache: () => ({
         getData: () => {
           return {}
-        }
+        },
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../site-grid-ref.js')
     expect(await getData(request)).toStrictEqual({ gridReference: undefined })
+    expect(mockClearPageData).toHaveBeenCalledWith('site-grid-ref')
   })
 
-  it('setData', async () => {
+  it('setData with site', async () => {
     const mockSetData = jest.fn()
     const mockUpdate = jest.fn()
     const site = [
@@ -153,6 +159,56 @@ describe('The site national grid reference page', () => {
         mitigationsAfterDevelopment: 'site-after-development.shape'
       }
     })
+  })
+
+  it('setData with no site', async () => {
+    const mockSetData = jest.fn()
+    const mockUpdate = jest.fn()
+
+    jest.doMock('../../../../services/api-requests.js', () => ({
+      tagStatus: {
+        NOT_STARTED: 'NOT_STARTED'
+      },
+      APIRequests: {
+        SITE: {
+          update: mockUpdate,
+          findByApplicationId: () => {
+            return []
+          }
+        },
+        tags: () => {
+          return { has: () => false }
+        }
+      }
+    }))
+    const { setData } = await import('../site-grid-ref.js')
+    const request = {
+      cache: () => ({
+        getData: () => ({
+          applicationId: '2342fce0-3067-4ca5-ae7a-23cae648e45c',
+          siteData: {
+            id: '12345',
+            address: '123 site street, Birmingham, B1 4HY',
+            name: 'site-name',
+            siteMapFiles: {
+              activity: 'site.pdf',
+              mitigationsDuringDevelopment: 'demo.jpg',
+              mitigationsAfterDevelopment: 'site-after-development.shape'
+            }
+          }
+        }),
+        setData: mockSetData,
+        getPageData: () => ({
+          payload: {
+            'site-grid-ref': 'NY123456'
+          }
+        })
+      })
+    }
+    await setData(request)
+
+    expect(mockSetData).toHaveBeenCalled()
+    expect(mockUpdate).toHaveBeenCalled()
   })
 
   it('should redirect user to site address and grid reference mismatch, when the site tag is in progress', async () => {

--- a/packages/web-service/src/pages/site/site-grid-ref/site-grid-ref.js
+++ b/packages/web-service/src/pages/site/site-grid-ref/site-grid-ref.js
@@ -35,6 +35,7 @@ export const setData = async request => {
 
 export const getData = async request => {
   const { applicationId } = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.SITE_GRID_REF.page)
   const site = await APIRequests.SITE.findByApplicationId(applicationId)
   let gridReference
   if (site.length) {

--- a/packages/web-service/src/pages/site/site-name/__tests__/site-name.spec.js
+++ b/packages/web-service/src/pages/site/site-name/__tests__/site-name.spec.js
@@ -2,6 +2,7 @@ describe('site-name page handler', () => {
   beforeEach(() => jest.resetModules())
   it('getData returns the correct object', async () => {
     const result = { name: 'site-name', applicationId: '2342fce0-3067-4ca5-ae7a-23cae648e45c' }
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       APIRequests: {
         SITE: {
@@ -15,16 +16,19 @@ describe('site-name page handler', () => {
       cache: () => ({
         getData: () => {
           return result
-        }
+        },
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../site-name.js')
     expect(await getData(request)).toStrictEqual({ name: 'site-name' })
+    expect(mockClearPageData).toHaveBeenCalledWith('site-name')
   })
 
   it('getData returns the site name undefined when there is no site', async () => {
     const result = { name: 'site-name', applicationId: '2342fce0-3067-4ca5-ae7a-23cae648e45c' }
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       APIRequests: {
         SITE: {
@@ -38,12 +42,14 @@ describe('site-name page handler', () => {
       cache: () => ({
         getData: () => {
           return result
-        }
+        },
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../site-name.js')
     expect(await getData(request)).toStrictEqual({ name: undefined })
+    expect(mockClearPageData).toHaveBeenCalled()
   })
 
   it('setData - update site', async () => {

--- a/packages/web-service/src/pages/site/site-name/site-name.js
+++ b/packages/web-service/src/pages/site/site-name/site-name.js
@@ -8,6 +8,7 @@ import { checkApplication } from '../../common/check-application.js'
 
 export const getData = async request => {
   const { applicationId } = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.NAME.page)
   const sites = await APIRequests.SITE.findByApplicationId(applicationId)
   let name
   if (sites.length) {

--- a/packages/web-service/src/pages/site/upload-map-of-mitigations-after-development/__tests__/upload-map-of-mitigations-after-development.spec.js
+++ b/packages/web-service/src/pages/site/upload-map-of-mitigations-after-development/__tests__/upload-map-of-mitigations-after-development.spec.js
@@ -3,6 +3,7 @@ describe('the map of the site showing the mitigations after development page pag
   beforeEach(() => jest.resetModules())
 
   it('getData', async () => {
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       tagStatus: {
         IN_PROGRESS: 'IN_PROGRESS',
@@ -18,12 +19,14 @@ describe('the map of the site showing the mitigations after development page pag
     }))
     const request = {
       cache: () => ({
-        getData: () => ({ })
+        getData: () => ({ }),
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../upload-map-of-mitigations-after-development.js')
     expect(await getData(request)).toBeNull()
+    expect(mockClearPageData).toHaveBeenCalledWith('upload-map-of-mitigations-after-development')
   })
 
   it('should calls the s3 upload and redirects to the site national grid reference page', async () => {

--- a/packages/web-service/src/pages/site/upload-map-of-mitigations-after-development/upload-map-of-mitigations-after-development.js
+++ b/packages/web-service/src/pages/site/upload-map-of-mitigations-after-development/upload-map-of-mitigations-after-development.js
@@ -7,6 +7,7 @@ import { uploadAndUpdateSiteMap } from '../common/site-map-upload.js'
 
 export const getData = async request => {
   const { applicationId } = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.UPLOAD_MAP_MITIGATIONS_AFTER_DEVELOPMENT.page)
   await moveTagInProgress(applicationId, SECTION_TASKS.SITES)
   return null
 }

--- a/packages/web-service/src/pages/site/upload-map-of-mitigations-during-development/__tests__/upload-map-of-mitigations-during-development.spec.js
+++ b/packages/web-service/src/pages/site/upload-map-of-mitigations-during-development/__tests__/upload-map-of-mitigations-during-development.spec.js
@@ -2,6 +2,7 @@ describe('the map of the site showing the mitigations during development page ha
   beforeEach(() => jest.resetModules())
 
   it('getData', async () => {
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       tagStatus: {
         IN_PROGRESS: 'IN_PROGRESS',
@@ -17,7 +18,8 @@ describe('the map of the site showing the mitigations during development page ha
     }))
     const request = {
       cache: () => ({
-        getData: () => ({})
+        getData: () => ({}),
+        clearPageData: mockClearPageData
       })
     }
 
@@ -25,6 +27,7 @@ describe('the map of the site showing the mitigations during development page ha
       '../upload-map-of-mitigations-during-development.js'
     )
     expect(await getData(request)).toBeNull()
+    expect(mockClearPageData).toHaveBeenCalledWith('upload-map-of-mitigations-during-development')
   })
 
   it('should calls the s3 upload and redirects to the add a map of the site showing the mitigations after development page', async () => {

--- a/packages/web-service/src/pages/site/upload-map-of-mitigations-during-development/upload-map-of-mitigations-during-development.js
+++ b/packages/web-service/src/pages/site/upload-map-of-mitigations-during-development/upload-map-of-mitigations-during-development.js
@@ -7,6 +7,7 @@ import { uploadAndUpdateSiteMap } from '../common/site-map-upload.js'
 
 export const getData = async request => {
   const { applicationId } = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.UPLOAD_MAP_MITIGATIONS_DURING_DEVELOPMENT.page)
   await moveTagInProgress(applicationId, SECTION_TASKS.SITES)
   return null
 }

--- a/packages/web-service/src/pages/site/upload-map/__tests__/upload-map.spec.js
+++ b/packages/web-service/src/pages/site/upload-map/__tests__/upload-map.spec.js
@@ -3,6 +3,7 @@ describe('the map of your activity at the development site page handler', () => 
   beforeEach(() => jest.resetModules())
 
   it('getData', async () => {
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../../services/api-requests.js', () => ({
       tagStatus: {
         IN_PROGRESS: 'IN_PROGRESS',
@@ -18,12 +19,14 @@ describe('the map of your activity at the development site page handler', () => 
     }))
     const request = {
       cache: () => ({
-        getData: () => ({ })
+        getData: () => ({ }),
+        clearPageData: mockClearPageData
       })
     }
 
     const { getData } = await import('../upload-map.js')
     expect(await getData(request)).toBeNull()
+    expect(mockClearPageData).toHaveBeenCalledWith('upload-map')
   })
 
   it('should calls the s3 upload and update the database with new activity file and redirects to the add a map of the site showing the mitigations during development page', async () => {

--- a/packages/web-service/src/pages/site/upload-map/upload-map.js
+++ b/packages/web-service/src/pages/site/upload-map/upload-map.js
@@ -7,6 +7,7 @@ import { uploadAndUpdateSiteMap } from '../common/site-map-upload.js'
 
 export const getData = async request => {
   const { applicationId } = await request.cache().getData()
+  await request.cache().clearPageData(siteURIs.UPLOAD_MAP.page)
   await moveTagInProgress(applicationId, SECTION_TASKS.SITES)
   return null
 }

--- a/packages/web-service/src/pages/supporting-information/__tests__/upload-supporting-information.spec.js
+++ b/packages/web-service/src/pages/supporting-information/__tests__/upload-supporting-information.spec.js
@@ -2,7 +2,7 @@
 describe('the upload-supporting-information page handler', () => {
   beforeEach(() => jest.resetModules())
 
-  it('should calls the s3 upload and redirects to the check-supporting-information page', async () => {
+  it('should call the s3 upload and redirects to the check-supporting-information page', async () => {
     const request = {
       cache: () => ({
         getData: () => ({
@@ -43,8 +43,20 @@ describe('the upload-supporting-information page handler', () => {
       })
   })
 
+  it('should not call the s3 upload and redirects to the check-supporting-information page', async () => {
+    const request = {
+      cache: () => ({
+        getData: () => ({}),
+        getPageData: jest.fn(() => ({}))
+      })
+    }
+    const { completion } = await import('../upload-supporting-information.js')
+    expect(await completion(request)).toStrictEqual('/check-supporting-information')
+  })
+
   it('getData sets the tag', async () => {
     const mockSet = jest.fn()
+    const mockClearPageData = jest.fn()
     jest.doMock('../../../services/api-requests.js', () => ({
       tagStatus: {
         NOT_STARTED: 'not-started',
@@ -65,11 +77,13 @@ describe('the upload-supporting-information page handler', () => {
       cache: () => ({
         getData: jest.fn(() => ({
           applicationId: '8d79bc16-02fe-4e3c-85ac-b8d792b59b94'
-        }))
+        })),
+        clearPageData: mockClearPageData
       })
     }
     const { getData } = await import('../upload-supporting-information.js')
     expect(await getData(request)).toBe(null)
+    expect(mockClearPageData).toHaveBeenCalledWith('upload-supporting-information')
     expect(mockSet).toHaveBeenCalledWith({ tag: 'supporting-information', tagState: 'in-progress' })
   })
 })

--- a/packages/web-service/src/pages/supporting-information/upload-supporting-information.js
+++ b/packages/web-service/src/pages/supporting-information/upload-supporting-information.js
@@ -15,6 +15,7 @@ export const completion = async request => {
 
 export const getData = async request => {
   const { applicationId } = await request.cache().getData()
+  await request.cache().clearPageData(FILE_UPLOADS.SUPPORTING_INFORMATION.FILE_UPLOAD.page)
   await moveTagInProgress(applicationId, SECTION_TASKS.SUPPORTING_INFORMATION)
   return null
 }


### PR DESCRIPTION
fix for: https://eaflood.atlassian.net/browse/SDDSIP-745

and improvement of unit test coverage of `web-service/src/pages/common/file-upload.js.`