### PR TITLE
fix: ensure database schemas are adhered to

### DIFF
--- a/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
@@ -374,4 +374,41 @@ describe('The habitat work end page', () => {
     const { getData } = await import('../habitat-work-end.js')
     expect(await getData(request)).toStrictEqual({ day: '10', month: '10', year: '3022' })
   })
+
+  it('seData can pad zeros at the start of the day or month, if only 1 digit is entered', async () => {
+    const mockSetData = jest.fn()
+    jest.doMock('../../../../../services/api-requests.js', () => ({
+      tagStatus: {
+        COMPLETE: 'complete'
+      },
+      APIRequests: {
+        APPLICATION: {
+          tags: () => {
+            return { get: () => 'in-progress' }
+          }
+        }
+      }
+    }))
+    const request = {
+      cache: () => ({
+        setData: mockSetData,
+        getData: () => ({
+          habitatData: {}
+        }),
+        getPageData: () => ({
+          payload: {
+            'habitat-work-end-day': '1',
+            'habitat-work-end-month': '7',
+            'habitat-work-end-year': new Date().getFullYear()
+          }
+        })
+      })
+    }
+    const { setData } = await import('../habitat-work-end.js')
+    await setData(request)
+    expect(mockSetData).toHaveBeenCalledWith({
+      habitatData:
+        { endDate: `${new Date().getFullYear()}-07-01` }
+    })
+  })
 })

--- a/packages/web-service/src/pages/habitat/a24/work-end/habitat-work-end.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/habitat-work-end.js
@@ -39,8 +39,17 @@ export const setData = async request => {
   const pageData = await request.cache().getPageData()
   const journeyData = await request.cache().getData()
 
-  const day = pageData.payload['habitat-work-end-day']
-  const month = pageData.payload['habitat-work-end-month']
+  let day = pageData.payload[`${habitatURIs.WORK_END.page}-day`]
+  let month = pageData.payload[`${habitatURIs.WORK_END.page}-month`]
+
+  if (day.length === 1) {
+    day = `0${day}` // Done to meet the schema requirements
+  }
+
+  if (month.length === 1) {
+    month = `0${month}` // Done to meet the schema requirements
+  }
+
   const year = pageData.payload['habitat-work-end-year']
   const endDate = `${year}-${month}-${day}`
 

--- a/packages/web-service/src/pages/habitat/a24/work-start/__tests__/habitat-work-start.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-start/__tests__/habitat-work-start.spec.js
@@ -334,4 +334,41 @@ describe('The habitat work start page', () => {
     const { getData } = await import('../habitat-work-start.js')
     expect(await getData(request)).toStrictEqual({ day: '10', month: '10', year: '3022' })
   })
+
+  it('seData can pad zeros at the start of the day or month, if only 1 digit is entered', async () => {
+    const mockSetData = jest.fn()
+    jest.doMock('../../../../../services/api-requests.js', () => ({
+      tagStatus: {
+        COMPLETE: 'complete'
+      },
+      APIRequests: {
+        APPLICATION: {
+          tags: () => {
+            return { get: () => 'in-progress' }
+          }
+        }
+      }
+    }))
+    const request = {
+      cache: () => ({
+        setData: mockSetData,
+        getData: () => ({
+          habitatData: {}
+        }),
+        getPageData: () => ({
+          payload: {
+            'habitat-work-start-day': '1',
+            'habitat-work-start-month': '7',
+            'habitat-work-start-year': new Date().getFullYear()
+          }
+        })
+      })
+    }
+    const { setData } = await import('../habitat-work-start.js')
+    await setData(request)
+    expect(mockSetData).toHaveBeenCalledWith({
+      habitatData:
+        { startDate: `${new Date().getFullYear()}-07-01` }
+    })
+  })
 })

--- a/packages/web-service/src/pages/habitat/a24/work-start/habitat-work-start.js
+++ b/packages/web-service/src/pages/habitat/a24/work-start/habitat-work-start.js
@@ -27,8 +27,17 @@ export const setData = async request => {
   const pageData = await request.cache().getPageData()
   const journeyData = await request.cache().getData()
 
-  const day = pageData.payload[`${habitatURIs.WORK_START.page}-day`]
-  const month = pageData.payload[`${habitatURIs.WORK_START.page}-month`]
+  let day = pageData.payload[`${habitatURIs.WORK_START.page}-day`]
+  let month = pageData.payload[`${habitatURIs.WORK_START.page}-month`]
+
+  if (day.length === 1) {
+    day = `0${day}` // Done to meet the schema requirements
+  }
+
+  if (month.length === 1) {
+    month = `0${month}` // Done to meet the schema requirements
+  }
+
   const year = pageData.payload[`${habitatURIs.WORK_START.page}-year`]
   const startDate = `${year}-${month}-${day}`
 


### PR DESCRIPTION
Chatted to Stu to make sure the approach for this was correct

For the years input - we should throw a joi error if the user only inputs 2 numbers, to ensure we future proof when the year might be 2100 for example

The design system discusses this e.g.
<img width="635" alt="image" src="https://user-images.githubusercontent.com/25173414/208722647-22a8eab1-1f4a-47c8-a571-a5bf5c1cd2bf.png">


For the month and day, we should always zero fill it, which I've done
