### PR TITLE
Error reporting for a failed batch request of return on AQP is not wo…

### DIFF
--- a/packages/connectors-lib/src/__tests__/power-apps.spec.js
+++ b/packages/connectors-lib/src/__tests__/power-apps.spec.js
@@ -166,6 +166,50 @@ describe('The powerapps connector', () => {
       .rejects.toThrowError(HTTPResponseError)
   })
 
+  it('batch request error case returns 404 and records the error', async () => {
+    jest.doMock('simple-oauth2', () => ({
+      __esModule: true,
+      ClientCredentials: jest.fn(() => ({
+        getToken: jest.fn(() => ({
+          token: { token_type: 'Bearer', access_token: '56GKJGKJHGS' },
+          expired: jest.fn()
+        }))
+      }))
+    }))
+
+    const errTxt = JSON.stringify({ error: { code: '0x80040217', message: "Entity 'sdds_license' With Id = 9635f51e-ae11-ee11-8f6e-002248c72853 Does Not Exist" } })
+
+    async function * generate () {
+      yield errTxt
+    }
+
+    const mockFetch = jest.fn(() => ({
+      ok: false,
+      status: 404,
+      body: Readable.from(generate()),
+      headers: { get: () => 'multipart/mixed;boundary=batch_batch123' }
+    }))
+    jest.doMock('node-fetch', () => ({ default: mockFetch }))
+    const { POWERAPPS } = await import('../power-apps.js')
+    const errorSpy = jest.spyOn(console, 'error')
+    const requestHandle = { batchId: 'batch123' }
+    const response = await POWERAPPS.batchRequest(requestHandle, 'batch-payload')
+    expect(response).toBe(errTxt)
+    expect(errorSpy).toHaveBeenCalled()
+    expect(mockFetch).toHaveBeenCalledWith('http://powerapps:8080/xyz/$batch', {
+      body: 'batch-payload',
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer 56GKJGKJHGS',
+        'Content-Type': 'multipart/mixed;boundary=batch_batch123',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Prefer: 'return=representation'
+      },
+      signal: expect.any(Object)
+    })
+  })
+
   it('batch request failure case fetch throws Error', async () => {
     jest.doMock('simple-oauth2', () => ({
       __esModule: true,

--- a/packages/connectors-lib/src/__tests__/power-apps.spec.js
+++ b/packages/connectors-lib/src/__tests__/power-apps.spec.js
@@ -182,6 +182,43 @@ describe('The powerapps connector', () => {
     })
   })
 
+  it('batch request error case returns 404 and records the response', async () => {
+    jest.doMock('simple-oauth2', () => ({
+      __esModule: true,
+      ClientCredentials: jest.fn(() => ({
+        getToken: jest.fn(() => ({
+          token: { token_type: 'Bearer', access_token: '56GKJGKJHGS' },
+          expired: jest.fn()
+        }))
+      }))
+    }))
+    const errTxt = JSON.stringify({ error: { code: '1000', message: 'Huston we have a problem' } })
+
+    const mockFetch = jest.fn(() => ({
+      ok: false,
+      status: 404,
+      json: () => (errTxt),
+      headers: { get: () => 'application/json' }
+    }))
+    jest.doMock('node-fetch', () => ({ default: mockFetch }))
+
+    const { POWERAPPS } = await import('../power-apps.js')
+    const requestHandle = { batchId: 'batch123' }
+    await POWERAPPS.batchRequest(requestHandle, 'batch-payload')
+    expect(mockFetch).toHaveBeenCalledWith('http://powerapps:8080/xyz/$batch', {
+      body: 'batch-payload',
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer 56GKJGKJHGS',
+        'Content-Type': 'multipart/mixed;boundary=batch_batch123',
+        'OData-MaxVersion': '4.0',
+        'OData-Version': '4.0',
+        Prefer: 'return=representation'
+      },
+      signal: expect.any(Object)
+    })
+  })
+
   it('batch request with status 400 throws HTTPResponseError', async () => {
     jest.doMock('simple-oauth2', () => ({
       __esModule: true,


### PR DESCRIPTION
The following is the output on the terminal:

`Batch request error: {"error":{"code":"0x80040217","message":"Entity 'sdds_license' With Id = 9635f51e-ae11-ee11-8f6e-002248c72853 Does Not Exist"}}`

![Screenshot 2023-07-21 at 18 23 17](https://github.com/DEFRA/wildlife-licencing/assets/42332389/9f34c2f9-1266-4913-ac8e-8b29cca61186)

