### PR TITLE
Did you disturb badgers was always being displayed on check your answers screen

### DIFF
--- a/packages/web-service/src/pages/returns/returns-check.njk
+++ b/packages/web-service/src/pages/returns/returns-check.njk
@@ -237,7 +237,7 @@
     {% endif %}
   {% endif %}
 
-  {% if data.disturbBadgersDetails or not data.disturbBadgersDetails %}
+  {% if data.disturbBadgers === true or data.disturbBadgers === false %}
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Did you disturb badgers?</dt>
@@ -266,20 +266,6 @@
         </div>
       </dl>
     {% endif %}
-  {% endif %}
-
-  {% if data.disturbBadgersDetails %}
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Describe the work carried out to create the artificial sett</dt>
-          <dd class="govuk-summary-list__value">{{ data.disturbBadgersDetails }}</dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="/a24/artificial-sett-details">
-            Change<span class="govuk-visually-hidden">Describe the work carried out to create the artificial sett</span>
-          </a>
-        </dd>
-      </div>
-    </dl>
   {% endif %}
 
   <dl class="govuk-summary-list">


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SDDSIP-1684

Regardless of which questions were required by the licence return the disturb badgers question would always appear on the check your answers screen. This PR only displays the question if it has been answered.