### PR TITLE
SDDSIP-1530 - Fix Do you want to upload supporting information? being populated

### DIFF
--- a/packages/web-service/src/pages/returns/__tests__/returns-upload.spec.js
+++ b/packages/web-service/src/pages/returns/__tests__/returns-upload.spec.js
@@ -4,6 +4,60 @@ import { APIRequests } from '../../../services/api-requests.js'
 jest.mock('../../../services/api-requests.js')
 
 describe('Returns upload functions', () => {
+  beforeEach(() => jest.resetModules())
+  describe('the getData function', () => {
+    it('returns yesNo as no when a value has been set', async () => {
+      const request = {
+        cache: () => ({
+          getData: () => ({
+            applicationId: '26a3e94f-2280-4ea5-ad72-920d53c110fc',
+            licenceId: '920d53c110fc',
+            returns: {
+              id: '123456789'
+            }
+          })
+        })
+      }
+      jest.doMock('../../../services/api-requests.js', () => ({
+        APIRequests: {
+          RETURNS: {
+            getLicenceReturn: jest.fn(() => ({
+              returnsUpload: false
+            }))
+          }
+        }
+      }))
+
+      const { getData } = await import('../returns-upload.js')
+      const result = await getData(request)
+      expect(result).toEqual({ yesNo: 'no' })
+    })
+
+    it('returns yesNo as undefined when no value has been set', async () => {
+      const request = {
+        cache: () => ({
+          getData: () => ({
+            applicationId: '26a3e94f-2280-4ea5-ad72-920d53c110fc',
+            licenceId: '920d53c110fc',
+            returns: {
+              id: '123456789'
+            }
+          })
+        })
+      }
+      jest.doMock('../../../services/api-requests.js', () => ({
+        APIRequests: {
+          RETURNS: {
+            getLicenceReturn: jest.fn(() => ({}))
+          }
+        }
+      }))
+
+      const { getData } = await import('../returns-upload.js')
+      const result = await getData(request)
+      expect(result).toEqual({ yesNo: undefined })
+    })
+  })
   describe('setData', () => {
     let mockRequest
 

--- a/packages/web-service/src/pages/returns/returns-upload.js
+++ b/packages/web-service/src/pages/returns/returns-upload.js
@@ -6,6 +6,23 @@ import { allCompletion, checkLicence } from './common-return-functions.js'
 
 const { UPLOAD } = ReturnsURIs
 
+export const getData = async request => {
+  const journeyData = await request.cache().getData()
+  const returnId = journeyData?.returns?.id
+  const licenceId = journeyData?.licenceId
+  let returnsUpload
+  if (returnId) {
+    const licenceReturn = await APIRequests.RETURNS.getLicenceReturn(licenceId, returnId)
+    returnsUpload = licenceReturn?.returnsUpload
+  }
+
+  // Once the user has added files we don't want to show this question to the user again,
+  // unless they remove all the files and then we want to default the value back to no
+  const yesNo = returnsUpload === undefined ? undefined : 'no'
+
+  return { yesNo }
+}
+
 export const setData = async request => {
   const journeyData = await request.cache().getData()
   const returnsUpload = boolFromYesNo(request.payload['yes-no'])
@@ -30,5 +47,6 @@ export const returnUpload = yesNoPage({
   uri: UPLOAD.uri,
   checkData: checkLicence,
   setData: setData,
+  getData: getData,
   completion: allCompletion
 })

--- a/packages/web-service/src/pages/returns/returns-upload.njk
+++ b/packages/web-service/src/pages/returns/returns-upload.njk
@@ -24,12 +24,12 @@
         {
           value: "yes",
           text: "Yes",
-          checked: payload['yes-no'] === 'yes'
+          checked: data.yesNo === 'yes' or payload['yes-no'] === 'yes'
         },
         {
           value: "no",
           text: "No",
-          checked: payload['yes-no'] === 'no'
+          checked: data.yesNo === 'no' or payload['yes-no'] === 'no'
         }
       ]
     }) }}


### PR DESCRIPTION
<img width="827" alt="image" src="https://github.com/DEFRA/wildlife-licencing/assets/141018006/ad468a60-898f-49b9-a141-f5e5c045952c">
Dele found an issue with this field not populating with the saved answer when he returned back to it. This was originally by design as once the user answered Yes, we would want them to then add files and then not display this question again. Instead the user needs to remove all the files and then select no. 

This fix makes the field value default to no if the user has removed all the files and then chooses to visit the page, which is then displayed. Otherwise it is left undefined.