### PR TITLE
Add Dependabot to repo

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
To help us keep on top of dependency updates, we add Dependabot to our repo, setting it up for both `npm` and `github-actions`.

We may wish to make settings changes further down the line (`open-pull-requests-limit`, `versioning-strategy` etc.) but for the time being we use the default settings.