### PR TITLE
Fix Dependabot not updating `develop` branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,8 +8,12 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  # We specify the develop branch since this is the one we do our work on
+  target-branch: "develop"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "daily"
+  # We specify the develop branch since this is the one we do our work on
+  target-branch: "develop"


### PR DESCRIPTION
We [previously added Dependabot to our repo](https://github.com/DEFRA/wildlife-licencing/pull/488) but found it wasn't raising updates. This is likely because we didn't specify that we want it to raise PRs against the `develop` branch. We therefore fix that here.