### PR TITLE
SDDSIP-1810 - Fix destroy date validation

### DIFF
--- a/packages/web-service/src/pages/returns/a24/destroy-date.njk
+++ b/packages/web-service/src/pages/returns/a24/destroy-date.njk
@@ -8,12 +8,23 @@
         }
     } %}
 {% set title = 'When did you destroy the vacant sett?' %}
+
+{% set  errMsg = null %}
+
+{% if error['destroy-date'] === "noDateSent" %}
+     {% set errMsg = "Enter the date you destroyed the vacant sett" %}
+{% elseif error['destroy-date'] === "invalidDate" %}
+    {% set errMsg = "The date must be a real date" %}
+{% elseif error['destroy-date'] === "dataInFuture" %}
+    {% set errMsg = "The date must be in the past" %}
+{% endif %}
+
 {% block pageContent %}
   {{ govukDateInput({
     id: "destroy-date",
     namePrefix: "destroy-date",
     name: "destroy-date",
-    errorMessage: { text: "Enter a date in the past" } if error['destroy-date'],
+    errorMessage: { text: errMsg if errMsg },
     items: [
       {
         classes: "govuk-input--width-2",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SDDSIP-1810

Previously only one validation message was being displayed above the field.