### PR TITLE
SDDSIP-1660 - Fix why-nil type comparison mismatch

### DIFF
--- a/packages/web-service/src/pages/returns/why-nil.njk
+++ b/packages/web-service/src/pages/returns/why-nil.njk
@@ -35,17 +35,17 @@
               {
                 value: data.THE_DEVELOPMENT_WORK_DID_NOT_HAPPEN,
                 text: "The development work did not happen",
-                checked: data.whyNil === data.THE_DEVELOPMENT_WORK_DID_NOT_HAPPEN
+                checked: data.whyNil == data.THE_DEVELOPMENT_WORK_DID_NOT_HAPPEN
               },
               {
                 value: data.THE_SETT_WAS_NOT_IN_ACTIVE_USE_BY_BADGERS,
                 text: "The sett was not in active use by badgers",
-                checked: data.whyNil === data.THE_SETT_WAS_NOT_IN_ACTIVE_USE_BY_BADGERS
+                checked: data.whyNil == data.THE_SETT_WAS_NOT_IN_ACTIVE_USE_BY_BADGERS
               },
               {
                 value: data.OTHER,
                 text: "Other",
-                checked: payload['why-nil'] === data.OTHER if payload['why-nil'] or data.whyNil === data.OTHER,
+                checked: payload['why-nil'] == data.OTHER if payload['why-nil'] or data.whyNil == data.OTHER,
                 conditional: {
                   html: otherDetailsWhyActions
                 }


### PR DESCRIPTION
Turns out for this one the conditional logic inside the template for selecting the radio buttons was comparing an integer against a string. The fix for this is to do a loose equality comparison instead of a strict one, so that: 
`'452120000' == 452120000` 
does evaluate to true. 

https://eaflood.atlassian.net/browse/SDDSIP-1660