### PR TITLE
SDDSIP-1734 - Redirect to 404 with home link if on returns declaratio…

### DIFF
--- a/packages/web-service/src/pages/error/__tests__/not-found.spec.js
+++ b/packages/web-service/src/pages/error/__tests__/not-found.spec.js
@@ -1,0 +1,29 @@
+describe('not-found page', () => {
+  beforeEach(() => jest.resetModules())
+
+  describe('the getData', () => {
+    it('returns includeHomeLink "true" when included in the query string', async () => {
+      const request = {
+        query: {
+          includeHomeLink: 'true'
+        }
+      }
+      const { getData } = await import('../not-found.js')
+      const result = await getData(request)
+      expect(result).toEqual({
+        includeHomeLink: 'true'
+      })
+    })
+
+    it('Does not include includeHomeLink when not included in the query string', async () => {
+      const request = {
+        query: {}
+      }
+      const { getData } = await import('../not-found.js')
+      const result = await getData(request)
+      expect(result).not.toEqual({
+        includeHomeLink: 'true'
+      })
+    })
+  })
+})

--- a/packages/web-service/src/pages/error/not-found.js
+++ b/packages/web-service/src/pages/error/not-found.js
@@ -1,0 +1,14 @@
+import pageRoute from '../../routes/page-route.js'
+import { ERRORS } from '../../uris.js'
+
+export const getData = async request => {
+  const includeHomeLink = request.query.includeHomeLink
+
+  return { includeHomeLink }
+}
+
+export default pageRoute({
+  page: ERRORS.NOT_FOUND.page,
+  uri: ERRORS.NOT_FOUND.uri,
+  getData: getData
+})

--- a/packages/web-service/src/pages/error/not-found.njk
+++ b/packages/web-service/src/pages/error/not-found.njk
@@ -1,6 +1,13 @@
 {% extends "information-page.njk" %}
 {% set title = 'Page not found' %}
 {% block pageContent %}
+
+  {% if data.includeHomeLink %}
+    <p class="govuk-body">
+      <a href="/applications">View licences and applications</a> 
+    </p> 
+  {% endif %}
+
   <p class="govuk-body">
     If you typed the web address, check it is correct.
   </p>
@@ -8,7 +15,7 @@
     If you pasted the web address, check you copied the entire address.
   </p>
   <p class="govuk-body">
-     if you need to speak to someone about your application.
+     If you need to speak to someone about your application.
   
     If the web address is correct or you selected a link or button,
     <a href="mailto:enquiries@naturalengland.org.uk" class="govuk-link">enquiries@naturalengland.org.uk</a>

--- a/packages/web-service/src/pages/returns/__tests__/common-return-functions.spec.js
+++ b/packages/web-service/src/pages/returns/__tests__/common-return-functions.spec.js
@@ -127,7 +127,7 @@ describe('the common return functions', () => {
       const { checkReturns } = await import('../common-return-functions.js')
       await checkReturns(request, h)
       expect(mockRedirect).toHaveBeenCalled()
-      expect(mockRedirect).toHaveBeenCalledWith('/applications')
+      expect(mockRedirect).toHaveBeenCalledWith('/not-found?includeHomeLink=true')
     })
   })
 

--- a/packages/web-service/src/pages/returns/common-return-functions.js
+++ b/packages/web-service/src/pages/returns/common-return-functions.js
@@ -1,5 +1,5 @@
 import { PowerPlatformKeys } from '@defra/wls-powerapps-keys'
-import { APPLICATIONS, ReturnsURIs } from '../../uris.js'
+import { APPLICATIONS, ERRORS, ReturnsURIs } from '../../uris.js'
 import Joi from 'joi'
 import { APIRequests } from '../../services/api-requests.js'
 import { getNextUri } from './get-next-uri.js'
@@ -95,7 +95,7 @@ export const checkReturns = async (request, h) => {
   const journeyData = await request.cache().getData()
 
   if (!journeyData.returns) {
-    return h.redirect(APPLICATIONS.uri)
+    return h.redirect(ERRORS.NOT_FOUND_LINK_HOME.uri)
   }
 
   return null

--- a/packages/web-service/src/pages/returns/returns-declaration.js
+++ b/packages/web-service/src/pages/returns/returns-declaration.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import pageRoute from '../../routes/page-route.js'
 import { ReturnsURIs } from '../../uris.js'
 import { APIRequests } from '../../services/api-requests.js'
-import { checkLicence } from './common-return-functions.js'
+import { checkLicence, checkReturns } from './common-return-functions.js'
 
 const { DECLARATION, CONFIRMATION } = ReturnsURIs
 
@@ -21,6 +21,6 @@ export default pageRoute({
   validator: Joi.object({
     'submit-return': Joi.any().required()
   }).options({ abortEarly: false, allowUnknown: true }),
-  checkData: checkLicence,
+  checkData: [checkReturns, checkLicence],
   completion: completion
 })

--- a/packages/web-service/src/routes/routes.js
+++ b/packages/web-service/src/routes/routes.js
@@ -180,6 +180,7 @@ import declarationOfReturns from '../pages/returns/returns-declaration.js'
 import { uploadReturnSupportingInformation } from '../pages/returns/returns-upload-file.js'
 import { returnUploadedFiles } from '../pages/returns/returns-uploaded-files.js'
 import confirmationOfReturns from '../pages/returns/returns-confirmation.js'
+import notFound from '../pages/error/not-found.js'
 
 import { signOut } from '../pages/sign-out/sign-out.js'
 
@@ -354,6 +355,7 @@ const routes = [
   ...returnsCheck,
   ...declarationOfReturns,
   ...confirmationOfReturns,
+  ...notFound,
 
   signOut,
   ...miscRoutes

--- a/packages/web-service/src/uris.js
+++ b/packages/web-service/src/uris.js
@@ -218,7 +218,8 @@ export const ReturnsURIs = {
 export const SIGN_OUT = { uri: '/sign-out', page: 'sign-out' }
 
 export const ERRORS = {
-  NOT_FOUND: { page: 'not-found' },
+  NOT_FOUND: { uri: '/not-found', page: 'not-found' },
+  NOT_FOUND_LINK_HOME: { uri: '/not-found?includeHomeLink=true', page: 'not-found' },
   SERVICE_ERROR: { page: 'service-error' }
 }
 


### PR DESCRIPTION
…n screen and already submitted

https://eaflood.atlassian.net/browse/SDDSIP-1734

Very different from the original bug. Discussed with Stuart Bamforth about what needs to be done if the user presses back after submitting a return and attempts to submit again. If they do attempt to submit again from the returns-declaration screen it will display a 404 page with a link at the top to go back to the applications and licences screen.