### PR TITLE
Fix red error line on destroy date

### DIFF
--- a/packages/web-service/src/pages/returns/a24/destroy-date.njk
+++ b/packages/web-service/src/pages/returns/a24/destroy-date.njk
@@ -24,7 +24,7 @@
     id: "destroy-date",
     namePrefix: "destroy-date",
     name: "destroy-date",
-    errorMessage: { text: errMsg if errMsg },
+    errorMessage: { text: errMsg } if errMsg,
     items: [
       {
         classes: "govuk-input--width-2",


### PR DESCRIPTION
I found another red line being displayed on first page load while doing smoke tests. This is the fix for it.