### PR TITLE
POC: Make returns send Not Applicable for certain fields when not completed by the user

### DIFF
--- a/packages/application-queue-processor/src/return-job-process.js
+++ b/packages/application-queue-processor/src/return-job-process.js
@@ -3,6 +3,83 @@ import db from 'debug'
 import { models } from '@defra/wls-database-model'
 import { postProcess } from './common.js'
 
+// These appear to be the only fields on the powerapps side are displayed regardless of the licence
+// activities selected. They prevent proceeding due to them being mandatory.
+// null values for boolean fields will be converted to "Not Applicable" (10000002)
+const returnsFields = [
+  {
+    name: 'obstructionByOneWayGates',
+    defaultValue: null
+  },
+  {
+    name: 'obstructionByOneWayGatesDetails',
+    defaultValue: 'N/A'
+  },
+  {
+    name: 'obstructionBlockingOrProofing',
+    defaultValue: null
+  },
+  {
+    name: 'obstructionBlockingOrProofingDetails',
+    defaultValue: 'N/A'
+  },
+  {
+    name: 'damageByHandOrMechanicalMeans',
+    defaultValue: null
+  },
+  {
+    name: 'damageByHandOrMechanicalMeansDetails',
+    defaultValue: 'N/A'
+  },
+  {
+    name: 'destroyVacantSettByHandOrMechanicalMeans',
+    defaultValue: null
+  },
+  {
+    name: 'disturbBadgers',
+    defaultValue: null
+  },
+  {
+    name: 'artificialSett',
+    defaultValue: null
+  },
+  {
+    name: 'artificialSettDetails',
+    defaultValue: 'N/A'
+  },
+  {
+    name: 'artificialSettCreatedBeforeClosure',
+    defaultValue: null
+  },
+  {
+    name: 'artificialSettFoundEvidence',
+    defaultValue: null
+  },
+  {
+    name: 'artificialSettFoundGridReference',
+    defaultValue: 'N/A'
+  },
+  {
+    name: 'welfareConcerns',
+    defaultValue: null
+  },
+  {
+    name: 'welfareConcernsDetails',
+    defaultValue: 'N/A'
+  }
+]
+
+// Ensure all the fields are filled with a default value even if it does not exist (has not been
+// answered by the user)
+export const populateAllMissingFields = (returnsData) => {
+  returnsFields.forEach(field => {
+    if (!returnsData[field.name]) {
+      returnsData[field.name] = field.defaultValue
+    }
+  })
+  return returnsData
+}
+
 export const buildApiObject = async returnId => {
   const debug = db('return-queue-processor:post-process')
 
@@ -13,11 +90,13 @@ export const buildApiObject = async returnId => {
     return null
   }
 
+  const returnData = populateAllMissingFields(returnResult.returnData)
+
   const payload = {
     return: {
       data: {
         licenceId: returnResult.licenceId,
-        ...returnResult.returnData
+        ...returnData
       },
       keys: {
         apiKey: returnResult.id,

--- a/packages/powerapps-lib/src/schema/tables/common.js
+++ b/packages/powerapps-lib/src/schema/tables/common.js
@@ -1,6 +1,20 @@
 // Helpers
 
 export const yesNoNASrc = s => s ? 100000000 : 100000001
+
+export const yesNoNotApplicableSrc = (s) => {
+  switch (s) {
+    case true:
+      return 100000000
+    case false:
+      return 100000001
+    case null:
+      return 100000002
+    default:
+      return null
+  }
+}
+
 export const yesNoNATgt = t => t === 100000000
 
 export const yesNoNASrcNeg = s => !s ? 100000000 : 100000001

--- a/packages/powerapps-lib/src/schema/tables/sdds-return-of-actions.js
+++ b/packages/powerapps-lib/src/schema/tables/sdds-return-of-actions.js
@@ -1,26 +1,26 @@
 import { Table, Column, Relationship, RelationshipType, OperationType } from '../schema.js'
-import { dateConvSrc, yesNoNASrc, yesNoNASrcNeg, yesNoNATgt, yesNoNATgtNeg } from './common.js'
+import { dateConvSrc, yesNoNASrc, yesNoNASrcNeg, yesNoNATgt, yesNoNATgtNeg, yesNoNotApplicableSrc } from './common.js'
 
 const SddsReturnA24Columns = [
-  new Column('sdds_obstructsettentrancesbymeansofonewaygates', 'obstructionByOneWayGates', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_obstructsettentrancesbymeansofonewaygates', 'obstructionByOneWayGates', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_obstructsettentrancesonewaydescription', 'obstructionByOneWayGatesDetails'),
-  new Column('sdds_obstructaccesstosettbyblockingorproofing', 'obstructionBlockingOrProofing', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_obstructaccesstosettbyblockingorproofing', 'obstructionBlockingOrProofing', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_blockingorproofingdescription', 'obstructionBlockingOrProofingDetails'),
-  new Column('sdds_damagesettbyhandsmechanicalmeans', 'damageByHandOrMechanicalMeans', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_damagesettbyhandsmechanicalmeans', 'damageByHandOrMechanicalMeans', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_damagebyhandmechanicalmeansdescription', 'damageByHandOrMechanicalMeansDetails'),
-  new Column('sdds_destroyvacantsettbyhandormechanicalmeans', 'destroyVacantSettByHandOrMechanicalMeans', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_destroyvacantsettbyhandormechanicalmeans', 'destroyVacantSettByHandOrMechanicalMeans', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_destroysettbyhandmechanicaldecsription', 'destroyVacantSettByHandOrMechanicalMeansDetails'),
   new Column('sdds_whendidyoudestroythevacantsett', 'destroyDate'),
-  new Column('sdds_didyoudisturbbadgers', 'disturbBadgers', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_didyoudisturbbadgers', 'disturbBadgers', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_disturbbadgerdescription', 'disturbBadgersDetails'),
-  new Column('sdds_didyoucreateanartificialsett', 'artificialSett', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_didyoucreateanartificialsett', 'artificialSett', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_whydidntyoucreateanartificialsett', 'noArtificialSettReason'), // Option WHY_DIDNT_YOU_CREATE_AN_ARTIFICIAL_SETT
   new Column('sdds_whycouldanartificialsettnotbemade', 'noArtificialSettReasonDetails'),
   new Column('sdds_artificialsettdescription', 'artificialSettDetails'),
   new Column('sdds_evidencebadgersfoundtheartificialsett', 'artificialSettFoundEvidence'),
-  new Column('sdds_artificialsettcreatedbeforesettwasclosed', 'artificialSettCreatedBeforeClosure', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_artificialsettcreatedbeforesettwasclosed', 'artificialSettCreatedBeforeClosure', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_artificialbadgersettgridreference', 'artificialSettFoundGridReference'),
-  new Column('sdds_concernsforbadgerswelfare', 'welfareConcerns', yesNoNASrc, yesNoNATgt),
+  new Column('sdds_concernsforbadgerswelfare', 'welfareConcerns', yesNoNotApplicableSrc, yesNoNATgt),
   new Column('sdds_badgerswelfaredescription', 'welfareConcernsDetails')
 ]
 


### PR DESCRIPTION
This is only a proof of concept and has not yet been tested thoroughly. I've tried to isolate the functionality to returns by creating a new data filter called `yesNoNotApplicableSrc`, which will only be applied to the relevant fields. This will minimise impact of any regression.