### PR TITLE
SDDSIP-1843: Fix licensable action regression

### DIFF
--- a/packages/web-service/src/pages/habitat/a24/activities/__tests__/habitat-activities.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/activities/__tests__/habitat-activities.spec.js
@@ -20,6 +20,7 @@ describe('The habitat activities page', () => {
       const { completion } = await import('../habitat-activities.js')
       expect(await completion(request)).toBe('/check-habitat-answers')
     })
+
     it('getData grabs habitat data from the cache when it is available', async () => {
       const cacheGetDataMock = jest.fn().mockResolvedValue({
         applicationId: '123',
@@ -94,6 +95,33 @@ describe('The habitat activities page', () => {
       })
 
       expect(getHabitatBySettIdMock).toHaveBeenCalledWith(applicationId, settId)
+    })
+
+    it('getData returns no habitat data on primary journey', async () => {
+      const applicationId = '321'
+      const request = {
+        query: { },
+        cache: () => ({
+          getData: () => {
+            return {
+              applicationId,
+              habitatData: {
+                methodIds: null
+              }
+            }
+          }
+        })
+      }
+
+      const { getData } = await import('../habitat-activities.js')
+      expect(await getData(request)).toEqual({
+        OBSTRUCT_SETT_WITH_GATES,
+        OBSTRUCT_SETT_WITH_BLOCK_OR_PROOF,
+        DAMAGE_A_SETT,
+        DESTROY_A_SETT,
+        DISTURB_A_SETT,
+        methodIds: []
+      })
     })
 
     it('if the user doesnt fill a checkbox - it raises an error', async () => {

--- a/packages/web-service/src/pages/habitat/a24/activities/habitat-activities.js
+++ b/packages/web-service/src/pages/habitat/a24/activities/habitat-activities.js
@@ -22,9 +22,11 @@ export const completion = async _request => habitatURIs.CHECK_YOUR_ANSWERS.uri
 
 export const getData = async request => {
   const journeyData = await request.cache().getData()
-  let methodIds = journeyData?.habitatData?.methodIds
+  let methodIds = journeyData?.habitatData?.methodIds || []
 
-  if (!methodIds) {
+  if (!methodIds.length && request.query.id) {
+    // If we're revisiting the page then `request.query.id` will be the sett id; so if we had no cached habitat data
+    // we can use this to retrieve the habitat site's methods
     const habitatSite = await APIRequests.HABITAT.getHabitatBySettId(journeyData.applicationId, request.query.id)
     methodIds = habitatSite.methodIds
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SDDSIP-1843

[We fixed a bug](https://github.com/DEFRA/wildlife-licencing/pull/531) which caused the "How will you affect the badgers in this sett?" page to not be populated with previous data when revisiting it, but this unfortunately introduced a regression that occurs when you first visit the page, as we are attempting to retrieve data using `request.query.id` which is not set on first visit. We fix this by only retrieving the data if we have this id.