### PR TITLE
Chore/fix develop failing date future test

### DIFF
--- a/packages/web-service/src/pages/habitat/a24/common/date-validator.js
+++ b/packages/web-service/src/pages/habitat/a24/common/date-validator.js
@@ -4,17 +4,19 @@ import { LicenceTypeConstants } from '../../../../common/licence-type-constants.
 import { PowerPlatformKeys } from '@defra/wls-powerapps-keys'
 import { inDateWindow } from '../../../../common/date-utils.js'
 
+export const validateDateInFuture = (pageDate, pageName) => {
+  // Is this in the past?
+  if (!isFuture(pageDate)) {
+    throwJoiError(pageName, 'Error', 'dateHasPassed')
+  }
+}
+
 /**
  *
  * @param {Date} pageDate - the test date
  * @param pageName
  */
 export const validateDateInWindow = (pageDate, pageName) => {
-  // Is this in the past?
-  if (!isFuture(pageDate)) {
-    throwJoiError(pageName, 'Error', 'dateHasPassed')
-  }
-
   const { CLOSED_SEASON_START, CLOSED_SEASON_END } =
     LicenceTypeConstants[PowerPlatformKeys.APPLICATION_TYPES.A24]
 

--- a/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
@@ -1,3 +1,5 @@
+class NoErrorThrownError extends Error {}
+
 describe('The habitat work end page', () => {
   beforeEach(() => jest.resetModules())
 
@@ -101,9 +103,10 @@ describe('The habitat work end page', () => {
         })
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
+        throw new NoErrorThrownError('Expected error not thrown')
       } catch (e) {
         expect(e.message).toBe('ValidationError')
-        expect(e.details[0].message).toBe('Error')
+        expect(e.details[0].type).toBe('noDateSent')
       }
     })
 
@@ -116,9 +119,10 @@ describe('The habitat work end page', () => {
         }
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
+        throw new NoErrorThrownError('Expected error not thrown')
       } catch (e) {
         expect(e.message).toBe('ValidationError')
-        expect(e.details[0].message).toBe('Error')
+        expect(e.details[0].type).toBe('noDateSent')
       }
     })
 
@@ -131,9 +135,10 @@ describe('The habitat work end page', () => {
         }
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
+        throw new NoErrorThrownError('Expected error not thrown')
       } catch (e) {
         expect(e.message).toBe('ValidationError')
-        expect(e.details[0].message).toBe('Error')
+        expect(e.details[0].type).toBe('dateHasPassed')
       }
     })
 
@@ -146,6 +151,7 @@ describe('The habitat work end page', () => {
         }
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
+        throw new NoErrorThrownError('Expected error not thrown')
       } catch (e) {
         expect(e.message).toBe('ValidationError')
         expect(e.details[0].type).toBe('outsideLicence')
@@ -172,9 +178,10 @@ describe('The habitat work end page', () => {
         })
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
+        throw new NoErrorThrownError('Expected error not thrown')
       } catch (e) {
         expect(e.message).toBe('ValidationError')
-        expect(e.details[0].message).toBeNull()
+        expect(e.details[0].type).toBe('endDateBeforeStart')
       }
     })
 

--- a/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
@@ -142,13 +142,13 @@ describe('The habitat work end page', () => {
         const payload = {
           'habitat-work-end-day': '1',
           'habitat-work-end-month': '12',
-          'habitat-work-end-year': (new Date().getFullYear()).toString()
+          'habitat-work-end-year': (new Date().getFullYear() + 1).toString()
         }
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
       } catch (e) {
         expect(e.message).toBe('ValidationError')
-        expect(e.details[0].message).toBeNull()
+        expect(e.details[0].type).toBe('outsideLicence')
       }
     })
 

--- a/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
@@ -1,4 +1,3 @@
-const Joi = require('joi')
 describe('The habitat work end page', () => {
   beforeEach(() => jest.resetModules())
 
@@ -132,10 +131,12 @@ describe('The habitat work end page', () => {
     })
 
     it('you cant pass a date in the past', async () => {
+      jest.setSystemTime(new Date('2023-01-01'))
+
       const payload = {
         'habitat-work-end-day': '11',
         'habitat-work-end-month': '11',
-        'habitat-work-end-year': (new Date().getFullYear() - 1).toString()
+        'habitat-work-end-year': '2022'
       }
       const { validator } = await import('../habitat-work-end.js')
 
@@ -151,10 +152,12 @@ describe('The habitat work end page', () => {
     })
 
     it('you cant pass a date outside of the licence season', async () => {
+      jest.setSystemTime(new Date('2023-01-01'))
+
       const payload = {
         'habitat-work-end-day': '1',
-        'habitat-work-end-month': '12',
-        'habitat-work-end-year': (new Date().getFullYear() + 1).toString()
+        'habitat-work-end-month': '1',
+        'habitat-work-end-year': '2024'
       }
       const { validator } = await import('../habitat-work-end.js')
 

--- a/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
@@ -1,5 +1,4 @@
-class NoErrorThrownError extends Error {}
-
+const Joi = require('joi')
 describe('The habitat work end page', () => {
   beforeEach(() => jest.resetModules())
 
@@ -86,76 +85,88 @@ describe('The habitat work end page', () => {
 
   describe('the validator function', () => {
     it('if the user does not input a day - it raises an error', async () => {
-      try {
-        const payload = {
-          'habitat-work-end-day': '',
-          'habitat-work-end-month': '10',
-          'habitat-work-end-year': (new Date().getFullYear())
-        }
-        jest.doMock('../../../../../session-cache/cache-decorator.js', () => {
-          return {
-            cacheDirect: () => {
-              return {
-                getData: () => `11-11-${new Date().getFullYear()}`
-              }
+      const payload = {
+        'habitat-work-end-day': '',
+        'habitat-work-end-month': '10',
+        'habitat-work-end-year': (new Date().getFullYear())
+      }
+      jest.doMock('../../../../../session-cache/cache-decorator.js', () => {
+        return {
+          cacheDirect: () => {
+            return {
+              getData: () => `11-11-${new Date().getFullYear()}`
             }
           }
-        })
-        const { validator } = await import('../habitat-work-end.js')
-        expect(await validator(payload))
-        throw new NoErrorThrownError('Expected error not thrown')
+        }
+      })
+      const { validator } = await import('../habitat-work-end.js')
+
+      let error
+      try {
+        await validator(payload)
       } catch (e) {
-        expect(e.message).toBe('ValidationError')
-        expect(e.details[0].type).toBe('noDateSent')
+        error = e
       }
+
+      expect(error.message).toBe('ValidationError')
+      expect(error.details[0].type).toBe('noDateSent')
     })
 
     it('if the user does not input a month - it raises an error', async () => {
-      try {
-        const payload = {
-          'habitat-work-end-day': '1',
-          'habitat-work-end-month': '',
-          'habitat-work-end-year': (new Date().getFullYear())
-        }
-        const { validator } = await import('../habitat-work-end.js')
-        expect(await validator(payload))
-        throw new NoErrorThrownError('Expected error not thrown')
-      } catch (e) {
-        expect(e.message).toBe('ValidationError')
-        expect(e.details[0].type).toBe('noDateSent')
+      const payload = {
+        'habitat-work-end-day': '1',
+        'habitat-work-end-month': '',
+        'habitat-work-end-year': (new Date().getFullYear())
       }
+      const { validator } = await import('../habitat-work-end.js')
+
+      let error
+      try {
+        await validator(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error.message).toBe('ValidationError')
+      expect(error.details[0].type).toBe('noDateSent')
     })
 
     it('you cant pass a date in the past', async () => {
-      try {
-        const payload = {
-          'habitat-work-end-day': '11',
-          'habitat-work-end-month': '11',
-          'habitat-work-end-year': (new Date().getFullYear() - 1).toString()
-        }
-        const { validator } = await import('../habitat-work-end.js')
-        expect(await validator(payload))
-        throw new NoErrorThrownError('Expected error not thrown')
-      } catch (e) {
-        expect(e.message).toBe('ValidationError')
-        expect(e.details[0].type).toBe('dateHasPassed')
+      const payload = {
+        'habitat-work-end-day': '11',
+        'habitat-work-end-month': '11',
+        'habitat-work-end-year': (new Date().getFullYear() - 1).toString()
       }
+      const { validator } = await import('../habitat-work-end.js')
+
+      let error
+      try {
+        await validator(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error.message).toBe('ValidationError')
+      expect(error.details[0].type).toBe('dateHasPassed')
     })
 
     it('you cant pass a date outside of the licence season', async () => {
-      try {
-        const payload = {
-          'habitat-work-end-day': '1',
-          'habitat-work-end-month': '12',
-          'habitat-work-end-year': (new Date().getFullYear() + 1).toString()
-        }
-        const { validator } = await import('../habitat-work-end.js')
-        expect(await validator(payload))
-        throw new NoErrorThrownError('Expected error not thrown')
-      } catch (e) {
-        expect(e.message).toBe('ValidationError')
-        expect(e.details[0].type).toBe('outsideLicence')
+      const payload = {
+        'habitat-work-end-day': '1',
+        'habitat-work-end-month': '12',
+        'habitat-work-end-year': (new Date().getFullYear() + 1).toString()
       }
+      const { validator } = await import('../habitat-work-end.js')
+
+      let error
+      try {
+        await validator(payload)
+      } catch (e) {
+        error = e
+      }
+
+      expect(error.message).toBe('ValidationError')
+      expect(error.details[0].type).toBe('outsideLicence')
     })
 
     it('you cant pass an end date before the start date', async () => {
@@ -178,7 +189,6 @@ describe('The habitat work end page', () => {
         })
         const { validator } = await import('../habitat-work-end.js')
         expect(await validator(payload))
-        throw new NoErrorThrownError('Expected error not thrown')
       } catch (e) {
         expect(e.message).toBe('ValidationError')
         expect(e.details[0].type).toBe('endDateBeforeStart')

--- a/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/__tests__/habitat-work-end.spec.js
@@ -1,5 +1,8 @@
 describe('The habitat work end page', () => {
-  beforeEach(() => jest.resetModules())
+  beforeEach(() => {
+    jest.resetModules()
+    jest.setSystemTime(new Date('2023-01-01'))
+  })
 
   describe('the checkData function', () => {
     it('checkData returns null if the startDate is set', async () => {
@@ -87,13 +90,13 @@ describe('The habitat work end page', () => {
       const payload = {
         'habitat-work-end-day': '',
         'habitat-work-end-month': '10',
-        'habitat-work-end-year': (new Date().getFullYear())
+        'habitat-work-end-year': '2023'
       }
       jest.doMock('../../../../../session-cache/cache-decorator.js', () => {
         return {
           cacheDirect: () => {
             return {
-              getData: () => `11-11-${new Date().getFullYear()}`
+              getData: () => '11-11-2023'
             }
           }
         }
@@ -115,7 +118,7 @@ describe('The habitat work end page', () => {
       const payload = {
         'habitat-work-end-day': '1',
         'habitat-work-end-month': '',
-        'habitat-work-end-year': (new Date().getFullYear())
+        'habitat-work-end-year': '2023'
       }
       const { validator } = await import('../habitat-work-end.js')
 
@@ -131,8 +134,6 @@ describe('The habitat work end page', () => {
     })
 
     it('you cant pass a date in the past', async () => {
-      jest.setSystemTime(new Date('2023-01-01'))
-
       const payload = {
         'habitat-work-end-day': '11',
         'habitat-work-end-month': '11',
@@ -152,8 +153,6 @@ describe('The habitat work end page', () => {
     })
 
     it('you cant pass a date outside of the licence season', async () => {
-      jest.setSystemTime(new Date('2023-01-01'))
-
       const payload = {
         'habitat-work-end-day': '1',
         'habitat-work-end-month': '1',

--- a/packages/web-service/src/pages/habitat/a24/work-end/habitat-work-end.js
+++ b/packages/web-service/src/pages/habitat/a24/work-end/habitat-work-end.js
@@ -4,7 +4,7 @@ import differenceInMonths from 'date-fns/differenceInMonths/index.js'
 import pageRoute from '../../../../routes/page-route.js'
 import { APIRequests } from '../../../../services/api-requests.js'
 import { habitatURIs } from '../../../../uris.js'
-import { validateDateInWindow } from '../common/date-validator.js'
+import { validateDateInFuture, validateDateInWindow } from '../common/date-validator.js'
 import { getHabitatById } from '../common/get-habitat-by-id.js'
 import { putHabitatById } from '../common/put-habitat-by-id.js'
 import { cacheDirect } from '../../../../session-cache/cache-decorator.js'
@@ -37,6 +37,7 @@ export const getData = async request => {
 
 export const validator = async (payload, context) => {
   const endDate = validatePageDate(payload, habitatURIs.WORK_END.page)
+  validateDateInFuture(endDate, habitatURIs.WORK_END.page)
   validateDateInWindow(endDate, habitatURIs.WORK_END.page)
 
   // Validate the end date with the start date

--- a/packages/web-service/src/pages/habitat/a24/work-start/habitat-work-start.js
+++ b/packages/web-service/src/pages/habitat/a24/work-start/habitat-work-start.js
@@ -9,7 +9,7 @@ import { putHabitatById } from '../common/put-habitat-by-id.js'
 import { checkApplication } from '../../../common/check-application.js'
 import { isCompleteOrConfirmed } from '../../../common/tag-functions.js'
 import { A24_SETT } from '../../../tasklist/a24-badger-licence.js'
-import { validateDateInWindow } from '../common/date-validator.js'
+import { validateDateInFuture, validateDateInWindow } from '../common/date-validator.js'
 import { extractDateFromPageDate, validatePageDate } from '../../../../common/date-utils.js'
 import { cacheDirect } from '../../../../session-cache/cache-decorator.js'
 import { LicenceTypeConstants } from '../../../../common/licence-type-constants.js'
@@ -31,6 +31,7 @@ export const getData = async request => {
 
 export const validator = async (payload, context) => {
   const startDate = validatePageDate(payload, habitatURIs.WORK_START.page)
+  validateDateInFuture(startDate, habitatURIs.WORK_START.page)
   validateDateInWindow(startDate, habitatURIs.WORK_START.page)
 
   // Validate the end date with the start date, if the end date is set


### PR DESCRIPTION
One of our tests just started randomly failing

<img width="1352" alt="image" src="https://github.com/DEFRA/wildlife-licencing/assets/141018006/d5f263df-d34c-404a-8114-516cae706647">


The problem was that the date was set to the 12 dec this year, which has now passed (see line 145 below)...

<img width="1007" alt="image" src="https://github.com/DEFRA/wildlife-licencing/assets/141018006/3db2d865-2bab-4af3-9f98-b0a65aadf57a">


Triggering the wrong validation error to be thrown for this test to pass:

<img width="542" alt="image" src="https://github.com/DEFRA/wildlife-licencing/assets/141018006/fb5a529a-160c-4c3d-90c0-eae3d9a69d0a">


I've rectified this by always adding a year to this years date to ensure it is always in the future (see Files changed).

I noticed two other issues with the tests

- The validation errors were being identified in the tests using the messages, which were sometimes null
   - I have changed this to check the Joi Validation error type instead
- If no error is ever thrown the test would always pass
   - I added an exception if no test is thrown to ensure the test will only pass if an exception is thrown and it is the right one
