### PR TITLE
Fix: db migrations `no pg_hba.conf entry` error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wildlife-licencing-service",
-  "version": "13.12.0-alpha.0",
+  "version": "13.13.0-fix-db-migrations.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wildlife-licencing-service",
-      "version": "13.12.0-alpha.0",
+      "version": "13.13.0-fix-db-migrations.0",
       "workspaces": [
         "./packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wildlife-licencing-service",
   "type": "module",
-  "version": "13.12.0-alpha.0",
+  "version": "13.13.0-fix-db-migrations.0",
   "engines": {
     "node": ">=16.13.0"
   },

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -11,10 +11,11 @@ To run the migrations ensure the necessary environment variables are set
 POSTGRES_USER
 POSTGRES_PW
 POSTGRES_DB
+POSTGRES_NOSSL
 ```
 These should already be exposed on CI, but locally you will need to set them yourself as so: 
 ```
-export POSTGRES_USER=exampleuser; export POSTGRES_PW=examplepassword; export POSTGRES_DB=exampledb;
+export POSTGRES_USER=exampleuser; export POSTGRES_PW=examplepassword; export POSTGRES_DB=exampledb; export POSTGRES_NOSSL=true;
 ```
 and then run the following command:
 

--- a/packages/api/sequelize.config.cjs
+++ b/packages/api/sequelize.config.cjs
@@ -7,6 +7,8 @@ const config = {
   database: process.env.POSTGRES_DB,
   host: process.env.POSTGRES_HOST,
   port: process.env.POSTGRES_PORT ? process.env.POSTGRES_PORT : 5432,
+  // We expect all our dbs to use ssl but connectors-lib sets the ssl options based on whether POSTGRES_NOSSL is set to
+  // `true` so we follow suit here; it may be required when running locally for example.
   ...(process.env?.POSTGRES_NOSSL !== 'true' && {
     dialectOptions: {
       ssl: {

--- a/packages/api/sequelize.config.cjs
+++ b/packages/api/sequelize.config.cjs
@@ -11,7 +11,15 @@ module.exports = {
     database: POSTGRES_DB,
     host: POSTGRES_HOST,
     port: POSTGRES_PORT,
-    dialect: 'postgres'
+    dialect: 'postgres',
+    ...(process.env?.POSTGRES_NOSSL !== 'true' && {
+      dialectOptions: {
+        ssl: {
+          require: true,
+          rejectUnauthorized: false
+        }
+      }
+    })
   },
   test: {
     username: POSTGRES_USER,
@@ -19,7 +27,15 @@ module.exports = {
     database: POSTGRES_DB,
     host: POSTGRES_HOST,
     port: POSTGRES_PORT,
-    dialect: 'postgres'
+    dialect: 'postgres',
+    ...(process.env?.POSTGRES_NOSSL !== 'true' && {
+      dialectOptions: {
+        ssl: {
+          require: true,
+          rejectUnauthorized: false
+        }
+      }
+    })
   },
   production: {
     username: POSTGRES_USER,
@@ -27,6 +43,14 @@ module.exports = {
     database: POSTGRES_DB,
     host: POSTGRES_HOST,
     port: POSTGRES_PORT,
-    dialect: 'postgres'
+    dialect: 'postgres',
+    ...(process.env?.POSTGRES_NOSSL !== 'true' && {
+      dialectOptions: {
+        ssl: {
+          require: true,
+          rejectUnauthorized: false
+        }
+      }
+    })
   }
 }

--- a/packages/api/sequelize.config.cjs
+++ b/packages/api/sequelize.config.cjs
@@ -1,56 +1,24 @@
-const POSTGRES_USER = process.env.POSTGRES_USER
-const POSTGRES_PW = process.env.POSTGRES_PW
-const POSTGRES_DB = process.env.POSTGRES_DB
-const POSTGRES_HOST = process.env.POSTGRES_HOST
-const POSTGRES_PORT = process.env.POSTGRES_PORT ? process.env.POSTGRES_PORT : 5432
+// All environments use environment variables for db config, so we define a single config that we use in every
+// environment, knowing that the settings that differ between environments will be pulled from the env vars.
+const config = {
+  dialect: 'postgres',
+  username: process.env.POSTGRES_USER,
+  password: process.env.POSTGRES_PW,
+  database: process.env.POSTGRES_DB,
+  host: process.env.POSTGRES_HOST,
+  port: process.env.POSTGRES_PORT ? process.env.POSTGRES_PORT : 5432,
+  ...(process.env?.POSTGRES_NOSSL !== 'true' && {
+    dialectOptions: {
+      ssl: {
+        require: true,
+        rejectUnauthorized: false
+      }
+    }
+  })
+}
 
 module.exports = {
-  development: {
-    username: POSTGRES_USER,
-    password: POSTGRES_PW,
-    database: POSTGRES_DB,
-    host: POSTGRES_HOST,
-    port: POSTGRES_PORT,
-    dialect: 'postgres',
-    ...(process.env?.POSTGRES_NOSSL !== 'true' && {
-      dialectOptions: {
-        ssl: {
-          require: true,
-          rejectUnauthorized: false
-        }
-      }
-    })
-  },
-  test: {
-    username: POSTGRES_USER,
-    password: POSTGRES_PW,
-    database: POSTGRES_DB,
-    host: POSTGRES_HOST,
-    port: POSTGRES_PORT,
-    dialect: 'postgres',
-    ...(process.env?.POSTGRES_NOSSL !== 'true' && {
-      dialectOptions: {
-        ssl: {
-          require: true,
-          rejectUnauthorized: false
-        }
-      }
-    })
-  },
-  production: {
-    username: POSTGRES_USER,
-    password: POSTGRES_PW,
-    database: POSTGRES_DB,
-    host: POSTGRES_HOST,
-    port: POSTGRES_PORT,
-    dialect: 'postgres',
-    ...(process.env?.POSTGRES_NOSSL !== 'true' && {
-      dialectOptions: {
-        ssl: {
-          require: true,
-          rejectUnauthorized: false
-        }
-      }
-    })
-  }
+  development: config,
+  test: config,
+  production: config
 }


### PR DESCRIPTION
Our db migrations aren't running in the dev environment, giving the following error:

```
no pg_hba.conf entry for host "...", user "...", database "...", no encryption
```

It seems this may be due to the db expecting an SSL connection. We therefore update the `sequelize.config.cjs` file we use when running migrations to set the required options.

Since we are applying the exact same configuration in every environment (with the only changes being down to the content of the environment variables) we also refactor the file to apply the same configuration object to each environment.

Note that as per `packages/connectors-lib/src/sequelize.js`, the SSL config is conditional based on the content of the `POSTGRES_NOSSL` env var; if this is set to `true` then we don't apply the SSL config. It may be required to set `POSTGRES_NOSSL=true` when running migrations locally.

The migration initially failed in the dev environment as the columns it tries to create already exist. Sequelize doesn't give an easy way of forcing migrations to be marked as done, so instead we log into the db and manually add the migration to the table of run migrations:
```sql
INSERT INTO "SequelizeMeta" (name) VALUES ('20240110142636-migration.cjs');
```