### PR TITLE
Fix: Add `statusCode` to `licence` in API spec

### DIFF
--- a/packages/api/openapi/licence.yaml
+++ b/packages/api/openapi/licence.yaml
@@ -4551,6 +4551,8 @@ components:
                 $ref: '#/components/schemas/timestamp'
         stateCode:
           type: number
+        statusCode:
+          type: number
         createdAt:
           $ref: '#/components/schemas/timestamp'
         updatedAt:

--- a/packages/api/openapi/licence.yaml
+++ b/packages/api/openapi/licence.yaml
@@ -3640,8 +3640,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
 
-
-
   '/application/types':
     get:
       description: Get the application types


### PR DESCRIPTION
An error was being caused in test due to `statusCode` having been removed from the `licence` object in the API spec at some point. We therefore add this back in.