### PR TITLE
fix: Empty address drop-down in site address page

### DIFF
--- a/packages/web-service/src/pages/site/select-address/__tests__/__snapshots__/select-address.spec.js.snap
+++ b/packages/web-service/src/pages/site/select-address/__tests__/__snapshots__/select-address.spec.js.snap
@@ -1,0 +1,311 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`site-got-postcode page template Matches the snapshot 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\" class=\\"govuk-template \\">
+  <head>
+    <meta charset=\\"utf-8\\">
+    <title>What is the site address?</title>
+    <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1, viewport-fit=cover\\">
+    <meta name=\\"theme-color\\" content=\\"#0b0c0c\\"> 
+    
+    <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+
+    
+      <link rel=\\"shortcut icon\\" sizes=\\"16x16 32x32 48x48\\" href=\\"/public/images/favicon.ico\\" type=\\"image/x-icon\\">
+      <link rel=\\"mask-icon\\" href=\\"/public/images/govuk-mask-icon.svg\\" color=\\"#0b0c0c\\"> 
+      <link rel=\\"apple-touch-icon\\" sizes=\\"180x180\\" href=\\"/public/images/govuk-apple-touch-icon-180x180.png\\">
+      <link rel=\\"apple-touch-icon\\" sizes=\\"167x167\\" href=\\"/public/images/govuk-apple-touch-icon-167x167.png\\">
+      <link rel=\\"apple-touch-icon\\" sizes=\\"152x152\\" href=\\"/public/images/govuk-apple-touch-icon-152x152.png\\">
+      <link rel=\\"apple-touch-icon\\" href=\\"/public/images/govuk-apple-touch-icon.png\\">
+    
+
+    
+    
+    <meta http-equiv=\\"x-ua-compatible\\" content=\\"IE=Edge\\"/>
+    <link href=\\"/public/stylesheets/main.css\\" rel=\\"stylesheet\\" type=\\"text/css\\"/>
+
+    
+    
+    <meta property=\\"og:image\\" content=\\"/public/images/govuk-opengraph-image.png\\">
+  </head>
+  <body class=\\"govuk-template__body \\">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    
+
+    <div class=\\"govuk-cookie-banner \\" data-nosnippet role=\\"region\\" aria-label=\\"Cookies on the wildlife licencing service\\">
+    
+    
+
+    <div class=\\"govuk-cookie-banner__message govuk-width-container\\"
+    >
+
+    <div class=\\"govuk-grid-row\\">
+      <div class=\\"govuk-grid-column-two-thirds\\">
+        
+        <h2 class=\\"govuk-cookie-banner__heading govuk-heading-m\\">Cookies on the wildlife licencing service</h2>
+        
+
+        <div class=\\"govuk-cookie-banner__content\\">
+  <p class=\\"govuk-body\\">We use some essential cookies to make this service work.</p>
+  <p class=\\"govuk-body\\">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+</div>
+      </div>
+    </div>
+
+      
+      <div class=\\"govuk-button-group\\">
+        
+          
+            
+              <a href=\\"/set-cookie-prefs?analytics=yes\\" role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button\\" data-module=\\"govuk-button\\">
+              Accept analytics cookies
+            </a>
+            
+          
+        
+          
+            
+              <a href=\\"/set-cookie-prefs?analytics=no\\" role=\\"button\\" draggable=\\"false\\" class=\\"govuk-button\\" data-module=\\"govuk-button\\">
+              Reject analytics cookies
+            </a>
+            
+          
+        
+          
+            <button class=\\"govuk-button\\" data-module=\\"govuk-button\\">
+              View cookies
+            </button>
+          
+        
+      </div>
+      
+    </div>
+  
+</div>
+
+
+
+
+
+
+
+    
+      <a href=\\"#main-content\\" class=\\"govuk-skip-link\\">Skip to main content</a>
+
+    
+
+    
+
+  <header class=\\"govuk-header \\" role=\\"banner\\" data-module=\\"govuk-header\\">
+    <div class=\\"govuk-header__container govuk-width-container\\">
+
+      <div class=\\"govuk-header__logo\\">
+        <a href=\\"/\\" class=\\"govuk-header__link govuk-header__link--homepage\\">
+          <span class=\\"govuk-header__logotype\\">
+            <!--[if gt IE 8]><!-->
+            <svg aria-hidden=\\"true\\" focusable=\\"false\\" class=\\"govuk-header__logotype-crown\\" xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 132 97\\" height=\\"30\\" width=\\"36\\">
+              <path fill=\\"currentColor\\" fill-rule=\\"evenodd\\" d=\\"M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z\\"></path>
+            </svg>
+            <span class=\\"govuk-header__logotype-text\\">
+              GOV.UK
+            </span>
+          </span>
+        </a>
+      </div>
+
+      <div class=\\"govuk-header__content\\">
+        <a href=\\"\\" class=\\"govuk-header__link govuk-header__link--service-name\\">Apply for a licence to do work that affects a protected species</a>
+
+        
+          <a class=\\"govuk-header__link signout-link\\" href=\\"\\">Sign in</a>
+        
+      </div>
+    </div>
+  </header>
+
+
+    
+      <div class=\\"govuk-width-container \\">
+        
+    <div class=\\"govuk-phase-banner\\">
+  <p class=\\"govuk-phase-banner__content\\">
+    <strong class=\\"govuk-tag govuk-phase-banner__content__tag\\">
+      beta
+    </strong>
+    <span class=\\"govuk-phase-banner__text\\">
+      <a class=\\"govuk-link\\" target=\\"_BLANK\\" href=\\"/feedback\\">Your feedback (opens in new tab)</a> can help us to improve this new service.
+    </span>
+  </p>
+</div>
+
+  <div class=\\"govuk-grid-row\\">
+    <div class=\\"govuk-grid-column-two-thirds\\">
+      
+        <div id=\\"backlink-div\\" hidden>&nbsp;</div>
+      
+    </div>
+    <div class=\\"govuk-grid-column-one-third\\">
+      
+    </div>
+  </div>
+
+        <main class=\\"govuk-main-wrapper \\" id=\\"main-content\\" role=\\"main\\">
+          
+<div class=\\"govuk-grid-row\\">
+    <div class=\\"govuk-grid-column-two-thirds\\">
+        
+    
+
+
+        <form method=\\"post\\" novalidate id=\\"main-content\\">
+            <fieldset class=\\"govuk-fieldset\\">
+  
+  <legend class=\\"govuk-fieldset__legend govuk-fieldset__legend--l display-wrapped\\">
+  
+    <h1 class=\\"govuk-fieldset__heading\\">
+      What is the site address?
+    </h1>
+  
+  </legend>
+  
+
+
+                
+    <p class=\\"govuk-body govuk-!-margin-bottom-6\\">
+      <span class=\\"govuk-!-font-weight-bold\\">Postcode</span>
+      <br>
+      
+      <br>
+      <a href=\\"\\" class=\\"govuk-link\\">Change</a>
+    </p>
+    
+
+<div class=\\"govuk-form-group\\">
+  <label class=\\"govuk-label govuk-label govuk-!-font-weight-bold\\" for=\\"siteAddress\\">
+    Select an address
+  </label>
+
+
+  <select class=\\"govuk-select\\" id=\\"siteAddress\\" name=\\"uprn\\">
+  
+    
+      <option value=\\"top\\">undefined addresses found</option>
+    
+  
+  </select>
+</div>
+
+    <p class=\\"govuk-body govuk-!-margin-bottom-6\\">
+        <a href=\\"\\" class=\\"govuk-link\\">I can’t find the address in the list</a>
+    </p>
+
+
+            
+
+</fieldset>
+
+
+            
+  
+
+
+  
+    
+  
+
+<button name=\\"continue\\" data-prevent-double-click=\\"true\\" class=\\"govuk-button govuk-!-margin-top-5\\" data-module=\\"govuk-button\\" id=\\"continue\\">
+  Continue
+</button>
+
+            <input type=\\"hidden\\" name=\\"crumb\\" value=\\"\\"/>
+        </form>
+    </div>
+</div>
+
+        </main>
+      </div>
+    
+
+    
+    
+    <footer class=\\"govuk-footer no-print\\" role=\\"contentinfo\\">
+  <div class=\\"govuk-width-container \\">
+    
+    <div class=\\"govuk-footer__meta\\">
+      <div class=\\"govuk-footer__meta-item govuk-footer__meta-item--grow\\">
+        
+          <h2 class=\\"govuk-visually-hidden\\">Support links</h2>
+          
+            <ul class=\\"govuk-footer__inline-list\\">
+              
+                <li class=\\"govuk-footer__inline-list-item\\">
+                  <a class=\\"govuk-footer__link\\" href=\\"\\">
+                    Cookies
+                  </a>
+                </li>
+              
+            </ul>
+          
+          
+        
+        <svg
+          aria-hidden=\\"true\\"
+          focusable=\\"false\\"
+          class=\\"govuk-footer__licence-logo\\"
+          xmlns=\\"http://www.w3.org/2000/svg\\"
+          viewBox=\\"0 0 483.2 195.7\\"
+          height=\\"17\\"
+          width=\\"41\\"
+        >
+          <path
+            fill=\\"currentColor\\"
+            d=\\"M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145\\"
+          />
+        </svg>
+        <span class=\\"govuk-footer__licence-description\\">
+          All content is available under the
+          <a
+            class=\\"govuk-footer__link\\"
+            href=\\"https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/\\"
+            rel=\\"license\\"
+          >Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class=\\"govuk-footer__meta-item\\">
+        <a
+          class=\\"govuk-footer__link govuk-footer__copyright-logo\\"
+          href=\\"https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/\\"
+        >© Crown copyright</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+
+
+    
+  <script nonce= src=\\"/public/javascript/all-min.js\\"></script>
+  <script nonce=>
+    window.GOVUKFrontend.initAll()
+  </script>
+  <script nonce=>
+    (function () {
+      const backLinkDiv = document.getElementById('backlink-div')
+      if (backLinkDiv) {
+        backLinkDiv.removeAttribute('hidden')
+      }
+      const backLinkAnchor = document.getElementsByClassName('govuk-back-link')[0]
+      if (backLinkAnchor) {
+          backLinkAnchor.addEventListener('click', function(event) {
+            event.preventDefault()
+            
+          })
+      }
+    })()
+  </script>
+
+  </body>
+</html>
+"
+`;

--- a/packages/web-service/src/pages/site/select-address/__tests__/select-address.spec.js
+++ b/packages/web-service/src/pages/site/select-address/__tests__/select-address.spec.js
@@ -1,3 +1,6 @@
+import path from 'path'
+import { compileTemplate } from '../../../../initialise-snapshot-tests.js'
+
 describe('site-got-postcode page handler', () => {
   beforeEach(() => jest.resetModules())
   it('getData returns the correct object', async () => {
@@ -146,5 +149,17 @@ describe('site-got-postcode page handler', () => {
       })
     }
     expect(await completion(request)).toBe('/check-site-answers')
+  })
+})
+
+describe('site-got-postcode page template', () => {
+  it('Matches the snapshot', async () => {
+    const template = await compileTemplate(path.join(__dirname, '../select-address.njk'))
+
+    const renderedHtml = template.render({
+      data: {}
+    })
+
+    expect(renderedHtml).toMatchSnapshot()
   })
 })

--- a/packages/web-service/src/pages/site/select-address/select-address.njk
+++ b/packages/web-service/src/pages/site/select-address/select-address.njk
@@ -14,7 +14,7 @@
 {% set items = [] %}
 {{ items.push({ value: 'top', text: data.addressLookup.length + ' addresses found' }) }}
 {% for a in data.addressLookup %}
-    {{ items.push({ value: a.Address.UPRN, text: a.Address.AddressLine }) }}
+    {{ items.push({ value: a.uprn, text: a.addressLine }) }}
 {% endfor %}
 
 {% block pageContent %}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SDDSIP-2084

The "What is the site address?" page in the "Give site information" flow didn't seem to have been fully updated for the v2 address lookup API, as it was still expecting to find address data in the older format (ie. each address contains `Address.UPRN` and `Address.AddressLine`, instead of just `uprn` and `addressLine`). This led to the page's address down-down being empty. We therefore update the template to extract the data correctly.