### PR TITLE
fix: Mismatched braces in templates

### DIFF
--- a/packages/web-service/src/pages/contact/common/email-address/email-address.njk
+++ b/packages/web-service/src/pages/contact/common/email-address/email-address.njk
@@ -12,7 +12,7 @@
             'any.required': { ref: '#email-address', text: 'What is the email address'  }
         }
     }
-} %}
+%}
 
 {% set labelId = 'email-address' %}
 

--- a/packages/web-service/src/pages/contact/invoice/invoice-purchase-order.njk
+++ b/packages/web-service/src/pages/contact/invoice/invoice-purchase-order.njk
@@ -7,7 +7,7 @@
           'string.empty': { ref: '#purchase-order', text: 'You have not entered a reference or purchase order number' }
         }
     }
-} %}
+%}
 
 {% set title = 'Enter a reference or purchase order number' %}
 {% set labelId = 'purchase-order' %}


### PR DESCRIPTION
Our [ungrouped content accessibility PR](https://github.com/DEFRA/wildlife-licencing/pull/640) introduced a couple of mismatched braces in files:

- packages/web-service/src/pages/contact/common/email-address/email-address.njk
- packages/web-service/src/pages/contact/invoice/invoice-purchase-order.njk

The first of these was spotted by QA due to it causing an error early in the application process; the second was found during a sweep of the templates. This PR removes them.