### PR TITLE
SDDSIP-1693 - Fix: License and ecologist detail - child error message…

### DIFF
--- a/packages/web-service/src/pages/contact/common/email-address/email-address.njk
+++ b/packages/web-service/src/pages/contact/common/email-address/email-address.njk
@@ -45,7 +45,7 @@
            {
                 value: "no",
                 text: data.email,
-                checked: true
+                checked: (not payload['change-email'] or payload['change-email'] == 'no')
             },
             {
               divider: "or"
@@ -55,7 +55,8 @@
               text: "Add a new email address",
               conditional: {
                 html: emailAddress
-              }
+              },
+              checked: (payload['change-email'] == 'yes')
             }
           ]
         }) }}


### PR DESCRIPTION
… is not displayed on What is User's email address at organisation?

https://eaflood.atlassian.net/browse/SDDSIP-1693

The error was being presented, but the relevant radio wasn't being selected based on the last payload submitted value

<img width="1083" alt="image" src="https://github.com/DEFRA/wildlife-licencing/assets/141018006/720c17c0-d79e-4481-b7f5-29c57f27fccf">
