### PR TITLE
Add additional logging for IDM JWT

### DIFF
--- a/packages/connectors-lib/src/__tests__/defra-id.spec.js
+++ b/packages/connectors-lib/src/__tests__/defra-id.spec.js
@@ -32,7 +32,8 @@ describe('Defra ID', () => {
 
     jest.doMock('jose', () => ({
       createRemoteJWKSet: jest.fn(() => 'ket-set'),
-      jwtVerify: () => ({ payload: 'payload' })
+      jwtVerify: () => ({ payload: 'payload' }),
+      decodeJwt: () => ('decoded')
     }))
   })
 
@@ -77,6 +78,15 @@ describe('Defra ID', () => {
       await DEFRA_ID.initialise('callback')
       const decode = await DEFRA_ID.verifyToken('jwt')
       expect(decode).toEqual('payload')
+    })
+  })
+
+  describe('decodeToken', () => {
+    it('decodes a token', async () => {
+      const { DEFRA_ID } = await import('../defra-id.js')
+      await DEFRA_ID.initialise('callback')
+      const decode = DEFRA_ID.decodeToken('jwt')
+      expect(decode).toEqual('decoded')
     })
   })
 })

--- a/packages/connectors-lib/src/defra-id.js
+++ b/packages/connectors-lib/src/defra-id.js
@@ -80,6 +80,19 @@ export const DEFRA_ID = {
     }
   },
   /**
+   * Returns the decoded token payload without verifying it
+   * @param jwt
+   * @returns {object}
+   */
+  decodeToken: jwt => {
+    try {
+      return jose.decodeJwt(jwt)
+    } catch (error) {
+      console.error(error)
+      throw new Error('Token decoding failure')
+    }
+  },
+  /**
    * Return the end session endpoint
    */
   getEndSession: () => defraIdInfo.endSessionEndpoint,

--- a/packages/web-service/src/handlers/__tests__/defra-idm-callback.spec.js
+++ b/packages/web-service/src/handlers/__tests__/defra-idm-callback.spec.js
@@ -13,6 +13,11 @@ describe('the defra IDM callback handler functions', () => {
       relationships: [],
       roles: []
     })
+    const mockDecodeToken = jest.fn().mockReturnValue({
+      exp: 1709567917,
+      iat: 1709567917,
+      nbf: 1709567917
+    })
     const mockGetUser = jest.fn().mockReturnValue({
       id: '81e36e15-88d0-41e2-9399-1c7646ecc5aa',
       uniqueReference: '1223',
@@ -23,7 +28,8 @@ describe('the defra IDM callback handler functions', () => {
     jest.doMock('@defra/wls-connectors-lib', () => ({
       DEFRA_ID: {
         fetchToken: mockFetchToken,
-        verifyToken: mockVerifyToken
+        verifyToken: mockVerifyToken,
+        decodeToken: mockDecodeToken
       }
     }))
     jest.doMock('../../services/api-requests.js', () => ({
@@ -75,13 +81,19 @@ describe('the defra IDM callback handler functions', () => {
       relationships: ['244c4959-0d09-ee11-8f6e-6045bd905113:fe4b4959-0d09-ee11-8f6e-6045bd905113:17 HENLEAZE ROAD MANAGEMENT COMPANY LIMITED:0:Employee:0'],
       roles: ['244c4959-0d09-ee11-8f6e-6045bd905113:fe4b4959-0d09-ee11-8f6e-6045bd905113:17 HENLEAZE ROAD MANAGEMENT COMPANY LIMITED:0:Employee:0']
     })
+    const mockDecodeToken = jest.fn().mockReturnValue({
+      exp: 1709567917,
+      iat: 1709567917,
+      nbf: 1709567917
+    })
     const mockCreateUser = jest.fn()
     const mockUpdateOrganisation = jest.fn()
     const mockUpdateUserOrganisation = jest.fn()
     jest.doMock('@defra/wls-connectors-lib', () => ({
       DEFRA_ID: {
         fetchToken: mockFetchToken,
-        verifyToken: mockVerifyToken
+        verifyToken: mockVerifyToken,
+        decodeToken: mockDecodeToken
       }
     }))
     jest.doMock('../../services/api-requests.js', () => ({

--- a/packages/web-service/src/handlers/defra-idm-callback.js
+++ b/packages/web-service/src/handlers/defra-idm-callback.js
@@ -4,6 +4,8 @@ import { APIRequests } from '../services/api-requests.js'
 import db from 'debug'
 const debug = db('web-service:authenticate')
 
+const jwtTimeToString = seconds => new Date(seconds * 1000).toString()
+
 /**
  * Search the database for a user with the id of the contact
  * @param request
@@ -107,6 +109,16 @@ export const defraIdmCallbackPreAuth = async (request, h) => {
     debug(`Got code: ${code.substring(0, 10)}...`)
     debug(`Time now: ${(new Date()).toString()}`)
     const token = await DEFRA_ID.fetchToken(code)
+    const payload = DEFRA_ID.decodeToken(token)
+    debug(`exp time: ${jwtTimeToString(payload.exp)}`)
+    debug(`iat time: ${jwtTimeToString(payload.iat)}`)
+    debug(`nbf time: ${jwtTimeToString(payload.nbf)}`)
+    debug(`Token payload: ${JSON.stringify(payload, null, 4)}`)
+
+    // We don't want to log actual tokens in production so we first check that this is a dev environment
+    if (process.env.NODE_ENV === 'development') {
+      debug(`Token: ${token}`)
+    }
     const tokenPayload = await DEFRA_ID.verifyToken(token)
     await consumeTokenPayload(request, tokenPayload)
   }


### PR DESCRIPTION
We add additional error logging to help us track down issues with IDM authentication. Immediately prior to verifying the token we debug log the `exp`, `iat` and `nbf` times in the token and in dev environments, we debug log the entire token.